### PR TITLE
feat(agent): add node-level alert analysis support

### DIFF
--- a/agent/app/clients/k8s.py
+++ b/agent/app/clients/k8s.py
@@ -34,16 +34,18 @@ class KubernetesClient:
         pod_name: str | None,
         workload: str | None = None,
         service_name: str | None = None,
+        node_name: str | None = None,
     ) -> K8sContext:
         target = AnalysisTarget(
             namespace=namespace,
             pod_name=pod_name,
             workload=workload,
             service_name=service_name,
+            node_name=node_name,
         )
         warnings: list[str] = []
 
-        if not namespace:
+        if not namespace and not node_name:
             warnings.append("namespace missing from alert labels")
             return K8sContext(
                 namespace=namespace,
@@ -76,7 +78,7 @@ class KubernetesClient:
         previous_logs: list[PodLogSnippet] = []
         pod_spec: dict[str, object] | None = None
 
-        if pod_name:
+        if namespace and pod_name:
             pod = self._read_pod(namespace, pod_name, warnings)
             pod_status = self._extract_pod_status(pod) if pod else None
             events = self._list_pod_events(namespace, pod_name, warnings)
@@ -89,9 +91,15 @@ class KubernetesClient:
             )
             previous_logs = self._get_previous_logs(namespace, pod, warnings)
             pod_spec = self._summarize_pod_spec(pod) if pod else None
-        else:
+        elif namespace:
             hint = self._build_pod_discovery_hint(namespace, workload, service_name)
             warnings.append(f"pod_name missing from alert labels.{hint}")
+
+        node_status: dict[str, object] | None = None
+        if node_name:
+            node_status = self.get_node_status(node_name)
+            if node_status is None:
+                warnings.append(f"node '{node_name}' not found or inaccessible")
 
         return K8sContext(
             namespace=namespace,
@@ -104,6 +112,7 @@ class KubernetesClient:
             target=target,
             current_logs=current_logs,
             pod_spec=pod_spec,
+            node_status=node_status,
         )
 
     def get_pod_status(self, namespace: str, pod_name: str) -> PodStatusSnapshot | None:
@@ -1410,12 +1419,14 @@ def resolve_alert_target(labels: dict[str, str]) -> AnalysisTarget:
         "workload",
         "app",
     ]
+    node_keys = ["node", "nodename", "exported_node"]
 
     return AnalysisTarget(
         namespace=_first_label_value(labels, namespace_keys),
         pod_name=_first_label_value(labels, pod_keys),
         workload=_first_label_value(labels, workload_keys),
         service_name=_first_label_value(labels, service_keys),
+        node_name=_first_label_value(labels, node_keys),
     )
 
 

--- a/agent/app/models/k8s.py
+++ b/agent/app/models/k8s.py
@@ -65,6 +65,7 @@ class AnalysisTarget:
     pod_name: str | None
     workload: str | None
     service_name: str | None
+    node_name: str | None = None
 
     def to_dict(self) -> dict[str, object]:
         return asdict(self)

--- a/agent/app/services/analysis.py
+++ b/agent/app/services/analysis.py
@@ -67,6 +67,7 @@ class AnalysisService:
             target.pod_name,
             target.workload,
             service_name=target.service_name,
+            node_name=target.node_name,
         )
         t_k8s = time.perf_counter()
 
@@ -580,6 +581,22 @@ def _build_prompt(
             "do not claim live Envoy behavior.\n\n"
         )
 
+    if k8s_context.target and k8s_context.target.node_name:
+        node_name = k8s_context.target.node_name
+        prompt += (
+            "This alert targets a specific Kubernetes node.\n"
+            f"Node name: {node_name}\n"
+            "For node-level alerts:\n"
+            "1. Use get_node_status(node_name) to check node conditions, "
+            "capacity, and taints.\n"
+            "2. Use get_node_metrics(node_name) to check CPU/memory usage.\n"
+            "3. Use list_cluster_events() to find node-related events.\n"
+            "4. If Prometheus is available, query node_* metrics "
+            "(e.g., node_filesystem_avail_bytes, node_memory_MemAvailable_bytes).\n"
+            "5. This is a node-level issue - focus on node health, disk, memory, "
+            "and system-level diagnostics rather than pod/namespace data.\n\n"
+        )
+
     if summary_block:
         prompt += summary_block
 
@@ -887,6 +904,7 @@ def _build_alert_fallback_key(request: AlertAnalysisRequest) -> str:
         _normalize_session_token(labels.get("alertname")),
         _normalize_session_token(labels.get("namespace")),
         _normalize_session_token(labels.get("pod")),
+        _normalize_session_token(labels.get("node")),
         _normalize_session_token(labels.get("workload")),
         _normalize_session_token(labels.get("destination_workload")),
         _normalize_session_token(labels.get("destination_service_name")),
@@ -929,20 +947,28 @@ def _collect_missing_data(
 ) -> list[str]:
     missing_data: list[str] = []
     target = _resolve_context_target(k8s_context)
-    if not target.namespace:
+    is_node_alert = bool(target.node_name)
+
+    if not target.namespace and not is_node_alert:
         missing_data.append("alert.labels.namespace")
-    if not target.pod_name:
+    if not target.pod_name and not is_node_alert:
         missing_data.append("alert.labels.pod")
-    if not target.service_name:
+    if not target.service_name and not is_node_alert:
         missing_data.append("analysis.target.service_name")
-    if k8s_context.pod_status is None:
-        missing_data.append("k8s.pod_status")
-    if not k8s_context.events:
-        missing_data.append("k8s.events")
-    if not _has_log_lines(k8s_context.current_logs):
-        missing_data.append("k8s.current_logs")
-    if not _has_log_lines(k8s_context.previous_logs) and _total_restart_count(k8s_context) > 0:
-        missing_data.append("k8s.previous_logs")
+
+    if is_node_alert and k8s_context.node_status is None:
+        missing_data.append("k8s.node_status")
+
+    if not is_node_alert:
+        if k8s_context.pod_status is None:
+            missing_data.append("k8s.pod_status")
+        if not k8s_context.events:
+            missing_data.append("k8s.events")
+        if not _has_log_lines(k8s_context.current_logs):
+            missing_data.append("k8s.current_logs")
+        if not _has_log_lines(k8s_context.previous_logs) and _total_restart_count(k8s_context) > 0:
+            missing_data.append("k8s.previous_logs")
+
     if capabilities.get("k8s_core") != "ok":
         missing_data.append("k8s.core_api")
     if capabilities.get("manifest_read") != "ok":
@@ -996,6 +1022,12 @@ def _resolve_analysis_quality(
     if capabilities.get("k8s_core") != "ok":
         return "low"
     target = _resolve_context_target(k8s_context)
+
+    if target.node_name:
+        if k8s_context.node_status is not None:
+            return "high"
+        return "medium"
+
     if not target.namespace:
         return "low"
     if not target.pod_name and not target.service_name:
@@ -1121,6 +1153,14 @@ def _fallback_summary(
     ]
     if k8s_context.namespace or k8s_context.pod_name:
         lines.append(f"target: namespace={k8s_context.namespace}, pod={k8s_context.pod_name}")
+    if k8s_context.target and k8s_context.target.node_name:
+        lines.append(f"target_node: {k8s_context.target.node_name}")
+    if k8s_context.node_status:
+        conditions = k8s_context.node_status.get("conditions", [])
+        if isinstance(conditions, list):
+            for cond in conditions:
+                if isinstance(cond, dict) and cond.get("status") != "False":
+                    lines.append(f"  node_condition: {cond.get('type')}={cond.get('status')}")
     if k8s_context.events:
         lines.append(f"recent_events ({len(k8s_context.events)}):")
         for event in k8s_context.events[:5]:

--- a/agent/pyproject.toml
+++ b/agent/pyproject.toml
@@ -33,6 +33,7 @@ target-version = "py310"
 
 [tool.ruff.lint]
 select = ["E", "F", "B", "I", "UP"]
+unfixable = ["F401"]
 
 [tool.ruff.format]
 quote-style = "double"

--- a/agent/tests/test_analysis_service.py
+++ b/agent/tests/test_analysis_service.py
@@ -22,8 +22,10 @@ from app.schemas.analysis import (
 from app.services.analysis import (
     AnalysisService,
     _categorize_analysis_error,
+    _collect_missing_data,
     _extract_first_paragraph,
     _parse_incident_summary,
+    _resolve_analysis_quality,
 )
 
 
@@ -37,6 +39,7 @@ class FakeKubernetesClient:
         pod_name: str | None,
         workload: str | None = None,
         service_name: str | None = None,
+        node_name: str | None = None,
     ) -> K8sContext:
         return K8sContext(
             namespace=self._context.namespace,
@@ -51,6 +54,7 @@ class FakeKubernetesClient:
                 pod_name=pod_name,
                 workload=workload,
                 service_name=service_name,
+                node_name=node_name,
             ),
             current_logs=self._context.current_logs,
             pod_spec=self._context.pod_spec,
@@ -1127,6 +1131,134 @@ def test_resolve_target_sentinel_skips_to_next_key() -> None:
     }
     target = resolve_alert_target(labels)
     assert target.workload == "reviews"
+
+
+# ── resolve_alert_target: node label extraction ──
+
+
+def test_resolve_target_node_label() -> None:
+    labels = {"alertname": "NodeFilesystemSpaceFillingUp", "node": "ip-10-0-1-179.ec2.internal"}
+    target = resolve_alert_target(labels)
+    assert target.node_name == "ip-10-0-1-179.ec2.internal"
+
+
+def test_resolve_target_nodename_label() -> None:
+    labels = {"alertname": "NodeFilesystemSpaceFillingUp", "nodename": "worker-01"}
+    target = resolve_alert_target(labels)
+    assert target.node_name == "worker-01"
+
+
+def test_resolve_target_node_priority_over_nodename() -> None:
+    labels = {"node": "primary-node", "nodename": "fallback-node"}
+    target = resolve_alert_target(labels)
+    assert target.node_name == "primary-node"
+
+
+def test_resolve_target_node_sentinel_filtered() -> None:
+    labels = {"node": "unknown"}
+    target = resolve_alert_target(labels)
+    assert target.node_name is None
+
+
+def test_resolve_target_node_with_namespace() -> None:
+    labels = {
+        "namespace": "monitoring",
+        "node": "worker-02",
+        "alertname": "NodeMemoryHighUtilization",
+    }
+    target = resolve_alert_target(labels)
+    assert target.node_name == "worker-02"
+    assert target.namespace == "monitoring"
+
+
+# ── _resolve_analysis_quality: node alerts ──
+
+
+def _make_node_k8s_context(
+    *,
+    node_name: str | None = "worker-01",
+    node_status: dict[str, object] | None = None,
+    namespace: str | None = None,
+) -> K8sContext:
+    return K8sContext(
+        namespace=namespace,
+        pod_name=None,
+        workload=None,
+        pod_status=None,
+        events=[],
+        previous_logs=[],
+        warnings=[],
+        target=AnalysisTarget(
+            namespace=namespace,
+            pod_name=None,
+            workload=None,
+            service_name=None,
+            node_name=node_name,
+        ),
+        node_status=node_status,
+    )
+
+
+def test_quality_node_alert_with_status_is_high() -> None:
+    ctx = _make_node_k8s_context(node_status={"name": "worker-01", "conditions": []})
+    quality = _resolve_analysis_quality(
+        k8s_context=ctx,
+        missing_data=[],
+        capabilities={"k8s_core": "ok"},
+        engine_issue=None,
+    )
+    assert quality == "high"
+
+
+def test_quality_node_alert_without_status_is_medium() -> None:
+    ctx = _make_node_k8s_context(node_status=None)
+    quality = _resolve_analysis_quality(
+        k8s_context=ctx,
+        missing_data=[],
+        capabilities={"k8s_core": "ok"},
+        engine_issue=None,
+    )
+    assert quality == "medium"
+
+
+def test_quality_node_alert_no_namespace_not_penalized() -> None:
+    ctx = _make_node_k8s_context(
+        node_status={"name": "worker-01", "conditions": []},
+        namespace=None,
+    )
+    quality = _resolve_analysis_quality(
+        k8s_context=ctx,
+        missing_data=[],
+        capabilities={"k8s_core": "ok"},
+        engine_issue=None,
+    )
+    assert quality == "high"
+
+
+# ── _collect_missing_data: node alerts ──
+
+
+def test_missing_data_node_alert_no_pod_not_reported() -> None:
+    ctx = _make_node_k8s_context(node_status={"name": "worker-01", "conditions": []})
+    missing = _collect_missing_data(
+        k8s_context=ctx,
+        tempo_context=None,
+        capabilities={"k8s_core": "ok", "manifest_read": "ok", "prometheus": "ok", "loki": "ok"},
+    )
+    assert "alert.labels.namespace" not in missing
+    assert "alert.labels.pod" not in missing
+    assert "k8s.pod_status" not in missing
+
+
+def test_missing_data_node_alert_node_status_missing() -> None:
+    ctx = _make_node_k8s_context(node_status=None)
+    missing = _collect_missing_data(
+        k8s_context=ctx,
+        tempo_context=None,
+        capabilities={"k8s_core": "ok", "manifest_read": "ok", "prometheus": "ok", "loki": "ok"},
+    )
+    assert "k8s.node_status" in missing
+    assert "alert.labels.pod" not in missing
 
 
 # ── _categorize_analysis_error ──


### PR DESCRIPTION
## Summary
- Node-level 알람(NodeFilesystemSpaceFillingUp 등)의 분석 품질을 "low"에서 "high"로 개선
- `resolve_alert_target()`에 node/nodename/exported_node 라벨 추출 추가
- `collect_context()`에서 node_status 사전 수집 및 node-aware prompt 가이드 추가
- Quality scoring/missing data 판정에서 node alert 경로 분리
- Ruff hook에 의한 import 자동 삭제 방지 (`unfixable = ["F401"]`)

## Test plan
- [x] `make lint` — All checks passed
- [x] `make test` — 163 passed (기존 + 신규 node 테스트 10건)
- [ ] NodeFilesystemSpaceFillingUp 알람으로 실제 분석 품질 확인