### PR TITLE
feat(chaos): harden teardown to prevent residual pod-netns state

### DIFF
--- a/chaos/Makefile
+++ b/chaos/Makefile
@@ -1,10 +1,13 @@
-.PHONY: help incident oomkilled crashloop imagepull networkdelay 404 500 503 504 ratings-multi
+.PHONY: help incident oomkilled crashloop imagepull networkdelay 404 500 503 504 ratings-multi verify-clean clean-all lint
 
 NAMESPACE ?= bookinfo
+NAMESPACES ?= bookinfo kube-rca
 KUBE_CONTEXT ?=
 WAIT_SECONDS ?= 120
 POLL_INTERVAL_SECONDS ?= 3
 FAULT_PERCENTAGE ?= 40
+RESTART_TIMEOUT ?= 120s
+SKIP_RESTART ?= false
 
 help: ## Show available targets
 	@awk 'BEGIN {FS = ":.*##"; printf "Usage:\n  make <target>\n\nTargets:\n"} /^[a-zA-Z0-9_-]+:.*##/ {printf "  %-16s %s\n", $$1, $$2}' $(MAKEFILE_LIST)
@@ -75,3 +78,18 @@ ratings-multi: ## Run combined ratings faults (404 from load-generator, 503 from
 	POLL_INTERVAL_SECONDS="$(POLL_INTERVAL_SECONDS)" \
 	FAULT_PERCENTAGE="$(FAULT_PERCENTAGE)" \
 	./scripts/run-504.sh
+
+verify-clean: ## Read-only check for residual chaos state (exit 1 if found)
+	@NAMESPACES="$(NAMESPACES)" \
+	KUBE_CONTEXT="$(KUBE_CONTEXT)" \
+	./scripts/verify_clean.sh
+
+clean-all: ## Force-remove residual chaos state and restart known workloads
+	@NAMESPACES="$(NAMESPACES)" \
+	KUBE_CONTEXT="$(KUBE_CONTEXT)" \
+	RESTART_TIMEOUT="$(RESTART_TIMEOUT)" \
+	SKIP_RESTART="$(SKIP_RESTART)" \
+	./scripts/clean_all.sh
+
+lint: ## Run shellcheck on all scripts/*.sh
+	@shellcheck -x scripts/*.sh

--- a/chaos/README.md
+++ b/chaos/README.md
@@ -57,9 +57,64 @@ make incident   # alias for oomkilled
 ## Environment
 
 - `NAMESPACE`: target namespace (default: `bookinfo`)
+- `NAMESPACES`: space-separated namespace list for `verify-clean` / `clean-all` (default: `"bookinfo kube-rca"`)
 - `KUBE_CONTEXT`: kubectl context (optional)
 - `WAIT_SECONDS`: wait timeout (default: `120`)
 - `POLL_INTERVAL_SECONDS`: polling interval (default: `3`)
 - `FAULT_PERCENTAGE`: fault injection percentage for 4xx/5xx (default: `40`)
+- `FORCE=true`: bypass the residual-chaos preflight (use only when intentionally stacking experiments)
+- `FORCE_RESTART=true`: rollout-restart target workloads on cleanup even for Istio-only scenarios
+- `RESTART_TIMEOUT`: `kubectl rollout status` timeout (default: `120s`)
+- `SKIP_RESTART=true`: on `clean-all`, skip the workload rollout restart (teardown only)
 
 Each scenario runs until you press Enter (or Ctrl+C), then cleans up.
+
+## Teardown guarantees
+
+Cleanup runs on normal exit **and** on Ctrl+C (via `trap cleanup EXIT`). It:
+
+1. `kubectl delete` the scenario's chaos manifest and any helper Deployment.
+2. (Chaos Mesh scenarios only) Wait up to 30s for `podnetworkchaos` / `podiochaos` / `podhttpchaos` finalizers to revert pod-netns rules.
+3. (Chaos Mesh scenarios, or any scenario with `FORCE_RESTART=true`) `kubectl rollout restart` every Deployment matching the scenario's label selector and wait for `rollout status`.
+4. Report any residual chaos objects that remain (e.g. stuck finalizer) and any pods that are still unhealthy.
+
+Scenarios that require pod restart on teardown (they inject pod-scoped state that `kubectl delete` does not revert):
+
+- `oomkilled` → `app=details`
+- `networkdelay` → `app=ratings`
+
+Scenarios that do **not** restart by default (pure Istio VirtualService fault injection):
+
+- `404`, `500`, `503`, `504`, `ratings-multi`
+
+## Pre-demo checklist
+
+Run before every demo to catch residual state from aborted runs:
+
+```bash
+cd chaos
+make verify-clean
+# Exit 0 → safe to start
+# Exit 1 → residue listed on stderr; run 'make clean-all' then re-verify
+```
+
+## Recovery
+
+If a scenario was aborted without running its cleanup (crashed terminal, missed Ctrl+C, manual CRD delete outside the script), the cluster can end up with orphaned chaos objects that keep injecting failures. Recover with:
+
+```bash
+cd chaos
+make clean-all                 # deletes residual CRDs + fault VS, restarts bookinfo workloads
+make verify-clean              # confirm exit 0
+
+# Scoped recovery (one namespace, no workload restart)
+NAMESPACES=bookinfo SKIP_RESTART=true make clean-all
+```
+
+See `presentation/docs/rca/2026-04-19-bookinfo-productpage-5xx.md` for a concrete incident where `clean-all`-equivalent action was required.
+
+## Lint
+
+```bash
+make lint   # shellcheck -x scripts/*.sh
+```

--- a/chaos/scripts/clean_all.sh
+++ b/chaos/scripts/clean_all.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# clean_all.sh — force-remove all residual chaos state and flush pod netns
+# on known bookinfo workloads.
+#
+# Use when a scenario teardown didn't run (crashed, Ctrl+C missed, demo
+# aborted) and 'make verify-clean' reports residue.
+#
+# Environment:
+#   NAMESPACES          Space-separated namespace list (default: "bookinfo kube-rca")
+#   KUBE_CONTEXT        kubectl context (optional)
+#   RESTART_TIMEOUT     kubectl rollout status timeout (default: 120s)
+#   SKIP_RESTART=true   Skip rollout restart (cleanup only)
+#
+# Exits non-zero if any delete or rollout fails.
+
+set -uo pipefail
+IFS=$'\n\t'
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+# shellcheck source-path=SCRIPTDIR
+# shellcheck source=./lib_chaos.sh
+. "${SCRIPT_DIR}/lib_chaos.sh"
+
+NAMESPACES=${NAMESPACES:-bookinfo kube-rca}
+RESTART_TIMEOUT=${RESTART_TIMEOUT:-120s}
+SKIP_RESTART=${SKIP_RESTART:-false}
+
+rc=0
+
+for ns in $NAMESPACES; do
+  if ! kubectl_local get namespace "$ns" >/dev/null 2>&1; then
+    log_info "namespace not present, skipping: ${ns}"
+    continue
+  fi
+
+  log_info "=== ${ns}: deleting residual chaos objects ==="
+
+  # Delete top-level chaos-mesh objects first so their pod-scoped children
+  # stop being re-created, then sweep the pod-scoped CRDs.
+  for kind in "${CHAOS_NS_KINDS[@]}" "${CHAOS_POD_KINDS[@]}"; do
+    names=$(kubectl_local -n "$ns" get "$kind" \
+      -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' \
+      --ignore-not-found 2>/dev/null || true)
+    [ -z "$names" ] && continue
+    while IFS= read -r name; do
+      [ -z "$name" ] && continue
+      log_info "deleting ${kind}/${name}"
+      if ! kubectl_local -n "$ns" delete "$kind" "$name" \
+           --ignore-not-found --wait=false >/dev/null 2>&1; then
+        log_warn "delete failed: ${kind}/${name}"
+        rc=1
+      fi
+    done <<<"$names"
+  done
+
+  log_info "=== ${ns}: deleting fault VirtualServices ==="
+  for vs in "${CHAOS_FAULT_VS[@]}"; do
+    if kubectl_local -n "$ns" get virtualservice "$vs" >/dev/null 2>&1; then
+      log_info "deleting VirtualService/${vs}"
+      if ! kubectl_local -n "$ns" delete virtualservice "$vs" \
+           --ignore-not-found >/dev/null 2>&1; then
+        log_warn "delete failed: VirtualService/${vs}"
+        rc=1
+      fi
+    fi
+  done
+
+  # Give chaos-mesh finalizers a moment to revert pod-netns rules before we
+  # restart workloads. Residual podnetworkchaos after 30s gets reported below.
+  for kind in "${CHAOS_POD_KINDS[@]}"; do
+    if ! wait_for_chaos_finalizer "$ns" "$kind" 30; then
+      log_warn "${kind} still present in ${ns} after 30s — proceeding anyway"
+      rc=1
+    fi
+  done
+
+  if [ "$SKIP_RESTART" = "true" ]; then
+    log_info "SKIP_RESTART=true, not restarting workloads in ${ns}"
+    continue
+  fi
+
+  if [ "$ns" = "bookinfo" ]; then
+    log_info "=== ${ns}: rollout restart known workloads ==="
+    for deploy in "${CHAOS_BOOKINFO_WORKLOADS[@]}"; do
+      if ! kubectl_local -n "$ns" get "deployment/${deploy}" >/dev/null 2>&1; then
+        continue
+      fi
+      log_info "rollout restart deployment/${deploy}"
+      if ! kubectl_local -n "$ns" rollout restart "deployment/${deploy}" >/dev/null 2>&1; then
+        log_warn "rollout restart failed: ${deploy}"
+        rc=1
+        continue
+      fi
+    done
+    for deploy in "${CHAOS_BOOKINFO_WORKLOADS[@]}"; do
+      if ! kubectl_local -n "$ns" get "deployment/${deploy}" >/dev/null 2>&1; then
+        continue
+      fi
+      if ! kubectl_local -n "$ns" rollout status "deployment/${deploy}" \
+           --timeout="$RESTART_TIMEOUT" >/dev/null 2>&1; then
+        log_warn "rollout status timed out: ${deploy}"
+        rc=1
+      fi
+    done
+  fi
+done
+
+log_info "=== final verification ==="
+if ! "${SCRIPT_DIR}/verify_clean.sh"; then
+  log_error "verify_clean still reports residue — manual intervention needed"
+  exit 1
+fi
+
+if [ "$rc" -ne 0 ]; then
+  log_warn "clean_all finished with soft errors (see warnings above)"
+  exit "$rc"
+fi
+log_ok "clean_all complete"

--- a/chaos/scripts/lib_chaos.sh
+++ b/chaos/scripts/lib_chaos.sh
@@ -1,0 +1,228 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+#
+# Shared helpers for chaos scenario orchestration.
+# Sourced by run_scenario.sh, verify_clean.sh, clean_all.sh.
+# Does not enable `set -e` so callers keep control.
+
+if [ -n "${LIB_CHAOS_SOURCED:-}" ]; then
+  # shellcheck disable=SC2317  # second clause runs only when executed, not sourced
+  return 0 2>/dev/null || exit 0
+fi
+LIB_CHAOS_SOURCED=1
+
+# Pod-scoped chaos-mesh CRDs that persist iptables/tc/BPF state inside pod netns.
+# Leaving these behind (even with empty spec) is the primary residue that caused
+# the 2026-04-19 productpage 5xx incident.
+CHAOS_POD_KINDS=(
+  podnetworkchaos.chaos-mesh.org
+  podiochaos.chaos-mesh.org
+  podhttpchaos.chaos-mesh.org
+)
+
+# Namespace-scoped top-level chaos-mesh resources that may keep reconciling
+# pod-scoped objects (Schedule in particular re-creates chaos on a cron).
+CHAOS_NS_KINDS=(
+  networkchaos.chaos-mesh.org
+  stresschaos.chaos-mesh.org
+  iochaos.chaos-mesh.org
+  httpchaos.chaos-mesh.org
+  schedule.chaos-mesh.org
+)
+
+# Fault-injection VirtualServices this repo is known to apply.
+# Leaving any of these after a demo keeps injecting 4xx/5xx and triggers alerts.
+CHAOS_FAULT_VS=(
+  ratings-fault-abort
+  ratings-combined-faults
+  details-fault-abort
+  reviews-fault-delay
+)
+
+# Workloads the chaos scenarios target. Used by clean_all.sh for a blanket
+# rollout restart so any stuck pod-netns state is flushed.
+# shellcheck disable=SC2034  # consumed by clean_all.sh via sourcing
+CHAOS_BOOKINFO_WORKLOADS=(
+  productpage-v1
+  ratings-v1
+  reviews-v1
+  reviews-v2
+  reviews-v3
+  details-v1
+)
+
+# Log helpers — fall through to caller's implementation if already defined.
+if ! declare -F log_info >/dev/null 2>&1; then
+  log_info() { printf "[INFO] %s\n" "$*"; }
+fi
+if ! declare -F log_ok >/dev/null 2>&1; then
+  log_ok() { printf "[OK] %s\n" "$*"; }
+fi
+if ! declare -F log_warn >/dev/null 2>&1; then
+  log_warn() { printf "[WARN] %s\n" "$*" >&2; }
+fi
+if ! declare -F log_error >/dev/null 2>&1; then
+  log_error() { printf "[ERROR] %s\n" "$*" >&2; }
+fi
+
+# kubectl wrapper honoring KUBE_CONTEXT. Run_scenario.sh already defines
+# kubectl_local; when not sourced from there we provide our own.
+if ! declare -F kubectl_local >/dev/null 2>&1; then
+  kubectl_local() {
+    if [ -n "${KUBE_CONTEXT:-}" ]; then
+      kubectl --context "$KUBE_CONTEXT" "$@"
+    else
+      kubectl "$@"
+    fi
+  }
+fi
+
+# find_residual_chaos_objects NAMESPACE
+#
+# Prints one `<kind>/<name>` per line for every chaos-mesh object that exists
+# in the namespace. Empty output means clean.
+# Exit status is always 0 (informational).
+find_residual_chaos_objects() {
+  local ns=$1
+  local kind
+  for kind in "${CHAOS_POD_KINDS[@]}" "${CHAOS_NS_KINDS[@]}"; do
+    # --ignore-not-found prevents failure when a CRD is not installed.
+    kubectl_local -n "$ns" get "$kind" \
+      -o jsonpath='{range .items[*]}{.kind}/{.metadata.name}{"\n"}{end}' \
+      --ignore-not-found 2>/dev/null || true
+  done
+}
+
+# find_residual_istio_faults NAMESPACE
+#
+# Prints one `VirtualService/<name>` per line for each known fault VS that
+# still exists. Empty output means clean.
+find_residual_istio_faults() {
+  local ns=$1
+  local vs
+  for vs in "${CHAOS_FAULT_VS[@]}"; do
+    if kubectl_local -n "$ns" get virtualservice "$vs" >/dev/null 2>&1; then
+      printf "VirtualService/%s\n" "$vs"
+    fi
+  done
+}
+
+# wait_for_chaos_finalizer NAMESPACE KIND TIMEOUT_SECONDS
+#
+# Chaos Mesh removes pod-scoped objects (podnetworkchaos etc.) asynchronously
+# after the parent CRD is deleted. Poll until no object of KIND remains in the
+# namespace, or TIMEOUT_SECONDS elapses. Returns 0 on clean, 1 on timeout.
+wait_for_chaos_finalizer() {
+  local ns=$1
+  local kind=$2
+  local timeout=${3:-30}
+  local deadline=$(( $(date +%s) + timeout ))
+
+  while [ "$(date +%s)" -le "$deadline" ]; do
+    local remaining
+    remaining=$(kubectl_local -n "$ns" get "$kind" \
+      -o jsonpath='{range .items[*]}{.metadata.name}{" "}{end}' \
+      --ignore-not-found 2>/dev/null || true)
+    if [ -z "${remaining// /}" ]; then
+      return 0
+    fi
+    sleep 2
+  done
+  return 1
+}
+
+# find_deployments_by_label NAMESPACE LABEL_SELECTOR
+#
+# Returns deployment names (one per line) that match the given label selector.
+# If the selector is in the form "app=foo", this translates Pod-level labels
+# to Deployments by using `kubectl get deployment -l`.
+find_deployments_by_label() {
+  local ns=$1
+  local selector=$2
+  if [ -z "$selector" ]; then
+    return 0
+  fi
+  kubectl_local -n "$ns" get deployment -l "$selector" \
+    -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' \
+    --ignore-not-found 2>/dev/null || true
+}
+
+# restart_workload NAMESPACE LABEL_SELECTOR TIMEOUT
+#
+# Roll-restarts every Deployment matching LABEL_SELECTOR and waits for
+# `rollout status` with the given TIMEOUT (kubectl duration, e.g. 120s).
+# Returns 0 when all rollouts complete, 1 if any restart or status wait fails.
+restart_workload() {
+  local ns=$1
+  local selector=$2
+  local timeout=${3:-120s}
+
+  if [ -z "$selector" ]; then
+    log_warn "restart_workload: empty label selector, skipping"
+    return 0
+  fi
+
+  local deployments
+  deployments=$(find_deployments_by_label "$ns" "$selector")
+  if [ -z "$deployments" ]; then
+    log_warn "restart_workload: no deployments matched '${selector}' in ${ns}"
+    return 0
+  fi
+
+  local rc=0
+  local deploy
+  while IFS= read -r deploy; do
+    [ -z "$deploy" ] && continue
+    log_info "rollout restart deployment/${deploy} (namespace ${ns})"
+    if ! kubectl_local -n "$ns" rollout restart "deployment/${deploy}"; then
+      log_error "rollout restart failed: ${deploy}"
+      rc=1
+      continue
+    fi
+    if ! kubectl_local -n "$ns" rollout status "deployment/${deploy}" --timeout="$timeout"; then
+      log_error "rollout status timed out: ${deploy}"
+      rc=1
+    fi
+  done <<<"$deployments"
+  return $rc
+}
+
+# verify_workload_healthy NAMESPACE LABEL_SELECTOR
+#
+# Returns 0 when every pod matching the selector reports `Ready=True` with no
+# container in a waiting state. Returns 1 otherwise. Prints a short reason
+# on failure.
+verify_workload_healthy() {
+  local ns=$1
+  local selector=$2
+
+  if [ -z "$selector" ]; then
+    return 0
+  fi
+
+  local pods
+  pods=$(kubectl_local -n "$ns" get pod -l "$selector" \
+    -o jsonpath='{range .items[*]}{.metadata.name}{"|"}{.status.conditions[?(@.type=="Ready")].status}{"|"}{.status.containerStatuses[*].state.waiting.reason}{"\n"}{end}' \
+    --ignore-not-found 2>/dev/null || true)
+
+  if [ -z "$pods" ]; then
+    log_warn "verify_workload_healthy: no pods matched '${selector}' in ${ns}"
+    return 0
+  fi
+
+  local bad=0
+  local line
+  while IFS= read -r line; do
+    [ -z "$line" ] && continue
+    local name ready waiting
+    name=${line%%|*}
+    local rest=${line#*|}
+    ready=${rest%%|*}
+    waiting=${rest#*|}
+    if [ "$ready" != "True" ] || [ -n "${waiting// /}" ]; then
+      log_warn "unhealthy pod: ${name} (ready=${ready:-?}, waiting=${waiting:-none})"
+      bad=1
+    fi
+  done <<<"$pods"
+  return $bad
+}

--- a/chaos/scripts/run_scenario.sh
+++ b/chaos/scripts/run_scenario.sh
@@ -45,6 +45,10 @@ log_ok() { printf "[OK] %s\n" "$*"; }
 log_warn() { printf "[WARN] %s\n" "$*" >&2; }
 log_error() { printf "[ERROR] %s\n" "$*" >&2; }
 
+# shellcheck source-path=SCRIPTDIR
+# shellcheck source=./lib_chaos.sh
+. "${SCRIPT_DIR}/lib_chaos.sh"
+
 is_valid_percentage() {
   local value=$1
   [[ "$value" =~ ^(100([.]0+)?|[0-9]{1,2}([.][0-9]+)?)$ ]]
@@ -170,6 +174,11 @@ REASON_MODE="waiting"
 USE_FAULT_PERCENTAGE="false"
 TMP_MANIFEST=""
 ORIG_CHAOS_MANIFEST=""
+# NEEDS_POD_RESTART=true for scenarios whose chaos leaves pod-netns state
+# (tc qdisc / iptables / BPF maps) that kubectl delete does not revert.
+# Such pods must be rollout-restarted during cleanup to guarantee a clean
+# baseline. Istio-only scenarios default to false; opt-in with FORCE_RESTART=true.
+NEEDS_POD_RESTART="false"
 
 case "$SCENARIO" in
   oomkilled)
@@ -180,6 +189,7 @@ case "$SCENARIO" in
     EXPECTED_REASON="OOMKilled"
     REASON_MODE="oom"
     DEFAULT_NAMESPACE="bookinfo"
+    NEEDS_POD_RESTART="true"
     ;;
   crashloop)
     TARGET_MANIFEST="${SCENARIOS_DIR}/crashloop/target-deployment.yaml"
@@ -197,6 +207,7 @@ case "$SCENARIO" in
   networkdelay)
     CHAOS_MANIFEST="${SCENARIOS_DIR}/networkdelay/network-delay.yaml"
     LABEL_SELECTOR="app=ratings"
+    NEEDS_POD_RESTART="true"
     ;;
   404)
     CHAOS_MANIFEST="${SCENARIOS_DIR}/404/fault-abort.yaml"
@@ -241,6 +252,21 @@ fi
 
 ensure_non_conflicting_ratings_faults
 
+# Residual-chaos preflight. A prior run that failed to teardown can leave
+# pod-scoped chaos state (podnetworkchaos etc.) behind; starting a new run
+# on top compounds the problem and was the root of the 2026-04-19 RCA.
+# Override with FORCE=true if intentional (e.g. reproducing a bug).
+residual=$(find_residual_chaos_objects "$NAMESPACE")
+if [ -n "$residual" ]; then
+  log_warn "Residual chaos objects detected in ${NAMESPACE}:"
+  printf '%s\n' "$residual" | sed 's|^|  |' >&2
+  if [ "${FORCE:-false}" != "true" ]; then
+    log_error "Refusing to start. Run 'make verify-clean' / 'make clean-all', or set FORCE=true to override."
+    exit 1
+  fi
+  log_warn "FORCE=true — proceeding despite residual state"
+fi
+
 if [ -n "$TARGET_MANIFEST" ]; then
   require_file "$TARGET_MANIFEST"
 fi
@@ -266,6 +292,8 @@ fi
 cleanup() {
   trap '' INT TERM
   log_info "Cleaning up..."
+
+  # 1. Delete chaos + target manifests (same as before).
   local cleanup_manifest="${ORIG_CHAOS_MANIFEST:-$CHAOS_MANIFEST}"
   if [ -n "$cleanup_manifest" ]; then
     kubectl_local -n "$NAMESPACE" delete -f "$cleanup_manifest" --ignore-not-found=true || true
@@ -273,6 +301,43 @@ cleanup() {
   if [ -n "$TARGET_MANIFEST" ]; then
     kubectl_local -n "$NAMESPACE" delete -f "$TARGET_MANIFEST" --ignore-not-found=true || true
   fi
+
+  # 2. Wait for Chaos Mesh pod-scoped CRDs to finalize. Chaos Mesh removes
+  # podnetworkchaos / podiochaos / podhttpchaos asynchronously via finalizer.
+  # If we restart before finalizer runs, the rules stay in pod netns.
+  if [ "$NEEDS_POD_RESTART" = "true" ]; then
+    for kind in "${CHAOS_POD_KINDS[@]}"; do
+      if ! wait_for_chaos_finalizer "$NAMESPACE" "$kind" 30; then
+        log_warn "${kind} still present in ${NAMESPACE} after 30s; restarting anyway"
+      fi
+    done
+  fi
+
+  # 3. Rollout restart affected workloads. Required for Chaos Mesh scenarios,
+  # opt-in for Istio-only scenarios via FORCE_RESTART=true.
+  if [ "$NEEDS_POD_RESTART" = "true" ] || [ "${FORCE_RESTART:-false}" = "true" ]; then
+    if [ -n "$LABEL_SELECTOR" ]; then
+      log_info "Rolling restart deployments matching: ${LABEL_SELECTOR}"
+      if ! restart_workload "$NAMESPACE" "$LABEL_SELECTOR" "${RESTART_TIMEOUT:-120s}"; then
+        log_warn "rollout restart had failures; inspect: kubectl -n ${NAMESPACE} get pod -l '${LABEL_SELECTOR}'"
+      fi
+    fi
+  fi
+
+  # 4. Post-cleanup verification. Report-only — do not fail cleanup if residue
+  # remains because we are likely exiting on user signal.
+  local remaining
+  remaining=$(find_residual_chaos_objects "$NAMESPACE")
+  if [ -n "$remaining" ]; then
+    log_warn "Residual chaos objects remain in ${NAMESPACE}:"
+    printf '%s\n' "$remaining" | sed 's|^|  |' >&2
+    log_warn "Run 'make clean-all NAMESPACES=${NAMESPACE}' for forced cleanup"
+  fi
+  if [ -n "$LABEL_SELECTOR" ]; then
+    verify_workload_healthy "$NAMESPACE" "$LABEL_SELECTOR" || \
+      log_warn "Workload readiness check failed; manual inspection recommended"
+  fi
+
   if [ -n "$TMP_MANIFEST" ] && [ -f "$TMP_MANIFEST" ]; then
     rm -f "$TMP_MANIFEST"
   fi

--- a/chaos/scripts/verify_clean.sh
+++ b/chaos/scripts/verify_clean.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# verify_clean.sh — read-only residual chaos detector.
+#
+# Exit 0  — no residual chaos objects or fault VirtualServices detected.
+# Exit 1  — one or more residues found. Names are printed to stderr.
+# Exit >1 — CLI / cluster access error.
+#
+# Environment:
+#   NAMESPACES      Space-separated namespace list (default: "bookinfo kube-rca")
+#   KUBE_CONTEXT    kubectl context (optional)
+
+set -euo pipefail
+IFS=$'\n\t'
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+# shellcheck source-path=SCRIPTDIR
+# shellcheck source=./lib_chaos.sh
+. "${SCRIPT_DIR}/lib_chaos.sh"
+
+NAMESPACES=${NAMESPACES:-bookinfo kube-rca}
+
+if ! command -v kubectl >/dev/null 2>&1; then
+  log_error "kubectl not found"
+  exit 2
+fi
+if ! kubectl_local config current-context >/dev/null 2>&1; then
+  log_error "kubectl cannot access cluster. Check KUBECONFIG / KUBE_CONTEXT."
+  exit 2
+fi
+
+found=0
+for ns in $NAMESPACES; do
+  if ! kubectl_local get namespace "$ns" >/dev/null 2>&1; then
+    log_info "namespace not present, skipping: ${ns}"
+    continue
+  fi
+
+  chaos=$(find_residual_chaos_objects "$ns")
+  faults=$(find_residual_istio_faults "$ns")
+
+  if [ -z "${chaos}${faults}" ]; then
+    log_ok "${ns}: clean"
+    continue
+  fi
+
+  found=1
+  log_warn "${ns}: residual state detected"
+  if [ -n "$chaos" ]; then
+    printf '%s\n' "$chaos" | sed "s|^|  chaos: |" >&2
+  fi
+  if [ -n "$faults" ]; then
+    printf '%s\n' "$faults" | sed "s|^|  fault: |" >&2
+  fi
+done
+
+if [ "$found" -ne 0 ]; then
+  log_error "residual chaos state — run 'make clean-all' or delete listed objects manually"
+  exit 1
+fi
+log_ok "all namespaces clean"


### PR DESCRIPTION
## Summary

2026-04-19 `bookinfo/productpage-v1` Istio 5xx 알림이 ~16.5시간 발화했던 인시던트 (RCA: `presentation/docs/rca/2026-04-19-bookinfo-productpage-5xx.md`) 재발 방지용 방어로직 추가.

직접 원인: chaos 실험이 종료돼도 `kubectl delete networkchaos`만으로는 pod netns의 tc/iptables/BPF 상태가 revert되지 않음. `podnetworkchaos/ratings-v1-...` 오브젝트가 35일간 잔존했고, `kubectl rollout restart`로 pod를 재생성한 뒤에야 5xx가 0%로 복귀.

## Changes

**Commit 1 (`09b81cb`) — 공용 라이브러리 + 신규 스크립트/타겟**
- `scripts/lib_chaos.sh`: `find_residual_chaos_objects`, `find_residual_istio_faults`, `wait_for_chaos_finalizer`, `restart_workload`, `verify_workload_healthy`
- `scripts/verify_clean.sh`: read-only 잔존 상태 점검 (pre-demo checklist용, exit 1 if found)
- `scripts/clean_all.sh`: 잔존 CRD/VS 강제 삭제 + bookinfo workload rollout restart
- `Makefile`: `verify-clean`, `clean-all`, `lint` 타겟 추가; `NAMESPACES`/`RESTART_TIMEOUT`/`SKIP_RESTART` env 추가

**Commit 2 (`eed7412`) — `run_scenario.sh` 보강**
- Preflight: 대상 namespace에 chaos-mesh 오브젝트 잔존 시 실행 거부 (`FORCE=true`로 우회)
- `NEEDS_POD_RESTART` 플래그: `oomkilled`, `networkdelay`는 teardown 시 자동 rollout restart (`FORCE_RESTART=true`로 Istio-only도 on)
- Teardown 시 pod-scoped CRD finalizer 30s 대기 → `restart_workload` → post-cleanup 검증 (잔존 오브젝트, pod Ready 여부)
- README: teardown 보장사항 / pre-demo checklist / recovery 섹션 + env var 표 업데이트

## Backwards compatibility

- 기존 `make oomkilled`, `make 503` 등 UX 동일 (cleanup이 더 철저해질 뿐)
- `trap cleanup EXIT` 경로 유지 — Ctrl+C도 보강된 cleanup 실행
- `FORCE=true`, `FORCE_RESTART=false` 등 escape hatch 제공

## Test plan

- [x] `bash -n` syntax check on all shell scripts
- [x] `shellcheck -x scripts/*.sh` — clean (0 warnings)
- [x] `make help` renders new targets
- [ ] Live cluster: `NAMESPACES=bookinfo make verify-clean` 으로 현재 상태 점검 (exit 0 기대)
- [ ] Live cluster: `kubectl apply -f scenarios/networkdelay/network-delay.yaml` 후 `make 503` 실행 → preflight exit 1 확인
- [ ] Live cluster: `make networkdelay` 정상 실행 → Ctrl+C → teardown 로그에 `rollout restart deployment/ratings-v1` 출력 확인, 5xx rate 복귀 확인
- [ ] Live cluster: `make clean-all` → `make verify-clean` exit 0 확인

## Out of scope

- Istio access log 활성화 (helm-charts 레포)
- Grafana `cx_connect_fail` panel 추가 (별도 observability 작업)
- RCA 가설 A(netns 잔류) vs B(cross-node mTLS) 재현 테스트