### PR TITLE
chore: chart discovery, OCI labels, English docs, ReDoc

### DIFF
--- a/.github/workflows/redoc-pages.yaml
+++ b/.github/workflows/redoc-pages.yaml
@@ -1,0 +1,83 @@
+name: redoc-pages
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "backend/docs/swagger.yaml"
+      - ".github/workflows/redoc-pages.yaml"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pages: write
+  id-token: write
+
+concurrency:
+  group: redoc-pages
+  cancel-in-progress: false
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install Redocly CLI
+        run: npm install -g @redocly/cli@1.34.0
+
+      - name: Build static ReDoc HTML
+        run: |
+          mkdir -p site/api
+          redocly build-docs backend/docs/swagger.yaml \
+            --output site/api/index.html \
+            --title "KubeRCA Backend API"
+
+      - name: Add api/ index redirect
+        run: |
+          cat > site/index.html <<'EOF'
+          <!doctype html>
+          <html>
+            <head>
+              <meta charset="utf-8" />
+              <meta http-equiv="refresh" content="0; url=./api/" />
+              <title>KubeRCA API Reference</title>
+            </head>
+            <body>
+              <p>Redirecting to <a href="./api/">/api/</a> ...</p>
+            </body>
+          </html>
+          EOF
+
+      - name: Deploy to gh-pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./site
+          publish_branch: gh-pages
+          keep_files: true
+          commit_message: "docs(api): publish ReDoc HTML for ${{ github.sha }}"
+
+      - name: Comment published URL on workflow run
+        if: success()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
+          SERVER_URL: ${{ github.server_url }}
+        run: |
+          OWNER="${REPO%%/*}"
+          REPONAME="${REPO##*/}"
+          PUBLISHED_URL="https://${OWNER}.github.io/${REPONAME}/api/"
+          echo "Published API reference: ${PUBLISHED_URL}"
+          echo "## ReDoc API reference published" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "- URL: ${PUBLISHED_URL}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Workflow run: ${SERVER_URL}/${REPO}/actions/runs/${RUN_ID}" >> "$GITHUB_STEP_SUMMARY"

--- a/agent/Dockerfile
+++ b/agent/Dockerfile
@@ -15,3 +15,10 @@ RUN uv pip install --system .
 EXPOSE 8000
 
 CMD ["sh", "-c", "exec uvicorn app.main:app --host 0.0.0.0 --port ${PORT:-8000} --workers ${WEB_CONCURRENCY:-1}"]
+
+LABEL org.opencontainers.image.source="https://github.com/kube-rca/kuberca"
+LABEL org.opencontainers.image.licenses="Apache-2.0"
+LABEL org.opencontainers.image.description="KubeRCA Agent"
+LABEL org.opencontainers.image.documentation="https://github.com/kube-rca/kuberca/tree/main/agent"
+LABEL org.opencontainers.image.vendor="KubeRCA"
+LABEL org.opencontainers.image.title="KubeRCA agent"

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -19,3 +19,10 @@ COPY --from=builder /build/main .
 
 ENTRYPOINT ["./main"]
 EXPOSE 8080
+
+LABEL org.opencontainers.image.source="https://github.com/kube-rca/kuberca"
+LABEL org.opencontainers.image.licenses="Apache-2.0"
+LABEL org.opencontainers.image.description="KubeRCA Backend"
+LABEL org.opencontainers.image.documentation="https://github.com/kube-rca/kuberca/tree/main/backend"
+LABEL org.opencontainers.image.vendor="KubeRCA"
+LABEL org.opencontainers.image.title="KubeRCA backend"

--- a/charts/kube-rca/Chart.yaml
+++ b/charts/kube-rca/Chart.yaml
@@ -8,3 +8,21 @@ dependencies:
   - name: postgresql
     version: 18.1.13
     repository: https://charts.bitnami.com/bitnami
+annotations:
+  artifacthub.io/category: monitoring-logging
+  artifacthub.io/license: Apache-2.0
+  artifacthub.io/links: |
+    - name: source
+      url: https://github.com/kube-rca/kuberca
+    - name: documentation
+      url: https://github.com/kube-rca/kuberca/tree/main/docs
+    - name: issues
+      url: https://github.com/kube-rca/kuberca/issues
+  artifacthub.io/maintainers: |
+    - name: kkamji98
+      email: ethan.kim@bunjang.co.kr
+  artifacthub.io/changes: |
+    - kind: added
+      description: values.schema.json for IDE/install validation
+    - kind: added
+      description: Artifact Hub annotations

--- a/charts/kube-rca/NOTICE
+++ b/charts/kube-rca/NOTICE
@@ -1,0 +1,10 @@
+KubeRCA Helm Chart
+Copyright 2026 KubeRCA contributors.
+
+This chart is licensed under the Apache License, Version 2.0.
+See https://www.apache.org/licenses/LICENSE-2.0 for the full license text.
+
+This chart packages and deploys the KubeRCA project components:
+  - Backend (Go)
+  - Agent (Python / FastAPI)
+  - Frontend (React / TypeScript)

--- a/charts/kube-rca/values.schema.json
+++ b/charts/kube-rca/values.schema.json
@@ -1,0 +1,708 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "KubeRCA Helm Chart Values",
+  "description": "Schema validation for the KubeRCA Helm chart values. Forward-compatible: additional properties are allowed at the root level so that newer chart features do not break older overrides.",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "nameOverride": {
+      "type": "string",
+      "description": "Override the name of the chart."
+    },
+    "fullnameOverride": {
+      "type": "string",
+      "description": "Override the full name of the release."
+    },
+    "hooks": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "waitJob": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "image": {
+              "type": "object",
+              "additionalProperties": true,
+              "properties": {
+                "repository": { "type": "string" },
+                "tag": { "type": "string" },
+                "pullPolicy": {
+                  "type": "string",
+                  "enum": ["Always", "IfNotPresent", "Never"]
+                }
+              }
+            },
+            "backoffLimit": { "type": "integer", "minimum": 0 },
+            "activeDeadlineSeconds": { "type": "integer", "minimum": 1 },
+            "checkInterval": { "type": "integer", "minimum": 1 },
+            "checkTimeout": { "type": "integer", "minimum": 1 },
+            "resources": { "type": "object" }
+          }
+        },
+        "waitForDb": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "enabled": { "type": "boolean" }
+          }
+        },
+        "waitForBackend": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "healthPath": { "type": "string" }
+          }
+        },
+        "waitForAgent": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "healthPath": { "type": "string" }
+          }
+        }
+      }
+    },
+    "postgresql": {
+      "type": "object",
+      "additionalProperties": true,
+      "description": "Top-level overrides for the Bitnami PostgreSQL sub-chart. Only top-level keys are validated here; refer to the Bitnami chart for the full sub-schema.",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "auth": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "username": { "type": "string" },
+            "database": { "type": "string" },
+            "password": { "type": "string" },
+            "existingSecret": { "type": "string" },
+            "secretKeys": {
+              "type": "object",
+              "additionalProperties": true,
+              "properties": {
+                "adminPasswordKey": { "type": "string" },
+                "userPasswordKey": { "type": "string" }
+              }
+            }
+          }
+        },
+        "primary": { "type": "object", "additionalProperties": true }
+      }
+    },
+    "externalDatabase": {
+      "type": "object",
+      "additionalProperties": true,
+      "description": "Optional external PostgreSQL configuration when postgresql.enabled=false.",
+      "properties": {
+        "host": { "type": "string" },
+        "port": { "type": "integer", "minimum": 1, "maximum": 65535 },
+        "user": { "type": "string" },
+        "database": { "type": "string" },
+        "existingSecret": { "type": "string" }
+      }
+    },
+    "image": {
+      "type": "object",
+      "additionalProperties": true,
+      "description": "Common image block. Per-component images live under backend.image / agent.image / frontend.image.",
+      "properties": {
+        "repository": { "type": "string" },
+        "tag": { "type": "string" },
+        "pullPolicy": {
+          "type": "string",
+          "enum": ["Always", "IfNotPresent", "Never"]
+        }
+      }
+    },
+    "ingress": {
+      "type": "object",
+      "additionalProperties": true,
+      "description": "Common ingress block. Per-component ingresses live under backend.ingress / agent.ingress / frontend.ingress.",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "className": { "type": "string" },
+        "ingressClassName": { "type": "string" },
+        "annotations": { "type": "object", "additionalProperties": true },
+        "hosts": { "type": "array" },
+        "tls": { "type": "array" }
+      }
+    },
+    "persistence": {
+      "type": "object",
+      "additionalProperties": true,
+      "description": "Optional persistence settings used by sub-charts or future chart features.",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "size": { "type": "string" },
+        "storageClass": { "type": ["string", "null"] }
+      }
+    },
+    "oidc": {
+      "type": "object",
+      "additionalProperties": true,
+      "description": "Top-level OIDC alias. Authoritative OIDC config is under backend.auth.oidc; this block is forward-compatible.",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "existingSecret": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "name": { "type": "string" },
+            "keys": {
+              "type": "object",
+              "additionalProperties": true,
+              "properties": {
+                "clientId": { "type": "string" },
+                "clientSecret": { "type": "string" },
+                "cookieSecret": { "type": "string" }
+              },
+              "required": ["clientId", "clientSecret"]
+            }
+          }
+        }
+      }
+    },
+    "webhookSecret": {
+      "type": ["string", "object", "null"],
+      "description": "Reserved placeholder for future HMAC webhook validation. Currently optional and not consumed by the chart."
+    },
+    "backend": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "replicaCount": { "type": "integer", "minimum": 0 },
+        "image": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "repository": { "type": "string" },
+            "tag": { "type": "string" },
+            "pullPolicy": {
+              "type": "string",
+              "enum": ["Always", "IfNotPresent", "Never"]
+            }
+          },
+          "required": ["repository"]
+        },
+        "service": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": ["ClusterIP", "NodePort", "LoadBalancer", "ExternalName"]
+            },
+            "port": { "type": "integer", "minimum": 1, "maximum": 65535 }
+          }
+        },
+        "containerPort": { "type": "integer", "minimum": 1, "maximum": 65535 },
+        "ingress": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "ingressClassName": { "type": "string" },
+            "annotations": { "type": "object", "additionalProperties": true },
+            "hosts": { "type": "array" },
+            "paths": { "type": "array", "items": { "type": "string" } },
+            "pathType": { "type": "string" },
+            "tls": { "type": "array" }
+          }
+        },
+        "resources": { "type": "object", "additionalProperties": true },
+        "podSecurityContext": { "type": "object", "additionalProperties": true },
+        "securityContext": { "type": "object", "additionalProperties": true },
+        "nodeSelector": { "type": "object", "additionalProperties": true },
+        "tolerations": { "type": "array" },
+        "affinity": { "type": "object", "additionalProperties": true },
+        "embedding": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "provider": { "type": "string", "enum": ["gemini"] },
+            "model": { "type": "string" },
+            "apiKey": {
+              "type": "object",
+              "additionalProperties": true,
+              "properties": {
+                "value": { "type": "string" },
+                "existingSecret": { "type": "string" },
+                "key": { "type": "string" }
+              }
+            }
+          }
+        },
+        "waitForDb": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "checkTimeout": { "type": "integer", "minimum": 1 },
+            "checkInterval": { "type": "integer", "minimum": 1 }
+          }
+        },
+        "postgresql": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "host": { "type": "string" },
+            "port": { "type": "integer", "minimum": 1, "maximum": 65535 },
+            "user": { "type": "string" },
+            "database": { "type": "string" },
+            "secret": {
+              "type": "object",
+              "additionalProperties": true,
+              "properties": {
+                "existingSecret": { "type": "string" },
+                "key": { "type": "string" }
+              }
+            },
+            "retry": {
+              "type": "object",
+              "additionalProperties": true,
+              "properties": {
+                "maxAttempts": { "type": "integer", "minimum": 1 },
+                "initialBackoffSeconds": { "type": "integer", "minimum": 0 },
+                "maxBackoffSeconds": { "type": "integer", "minimum": 1 }
+              }
+            }
+          }
+        },
+        "slack": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "token": { "type": "string" },
+            "channelId": { "type": "string" },
+            "secret": {
+              "type": "object",
+              "additionalProperties": true,
+              "properties": {
+                "existingSecret": { "type": "string" },
+                "tokenKey": { "type": "string" },
+                "channelIdKey": { "type": "string" }
+              }
+            }
+          }
+        },
+        "flapping": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "detectionWindowMinutes": { "type": "integer", "minimum": 1 },
+            "cycleThreshold": { "type": "integer", "minimum": 1 },
+            "clearanceWindowMinutes": { "type": "integer", "minimum": 1 }
+          }
+        },
+        "analysis": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "manualAnalyzeSeverities": { "type": "string" }
+          }
+        },
+        "auth": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "allowSignup": { "type": "boolean" },
+            "admin": {
+              "type": "object",
+              "additionalProperties": true,
+              "properties": {
+                "username": { "type": "string" },
+                "password": { "type": "string" }
+              }
+            },
+            "jwt": {
+              "type": "object",
+              "additionalProperties": true,
+              "properties": {
+                "secret": { "type": "string" },
+                "accessTtl": { "type": "string" },
+                "refreshTtl": { "type": "string" }
+              }
+            },
+            "cookie": {
+              "type": "object",
+              "additionalProperties": true,
+              "properties": {
+                "secure": { "type": "boolean" },
+                "sameSite": {
+                  "type": "string",
+                  "enum": ["Strict", "Lax", "None"]
+                },
+                "domain": { "type": "string" },
+                "path": { "type": "string" }
+              }
+            },
+            "oidc": {
+              "type": "object",
+              "additionalProperties": true,
+              "properties": {
+                "enabled": { "type": "boolean" },
+                "issuer": { "type": "string" },
+                "redirectUri": { "type": "string" },
+                "allowedDomains": {
+                  "type": "array",
+                  "items": { "type": "string" }
+                },
+                "allowedEmails": {
+                  "type": "array",
+                  "items": { "type": "string" }
+                },
+                "secret": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "properties": {
+                    "existingSecret": { "type": "string" },
+                    "keys": {
+                      "type": "object",
+                      "additionalProperties": true,
+                      "properties": {
+                        "clientId": { "type": "string" },
+                        "clientSecret": { "type": "string" },
+                        "cookieSecret": { "type": "string" }
+                      },
+                      "required": ["clientId", "clientSecret"]
+                    }
+                  }
+                }
+              }
+            },
+            "cors": {
+              "type": "object",
+              "additionalProperties": true,
+              "properties": {
+                "allowedOrigins": {
+                  "type": "array",
+                  "items": { "type": "string" }
+                }
+              }
+            },
+            "secret": {
+              "type": "object",
+              "additionalProperties": true,
+              "properties": {
+                "existingSecret": { "type": "string" },
+                "name": { "type": "string" },
+                "keys": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "properties": {
+                    "adminUsername": { "type": "string" },
+                    "adminPassword": { "type": "string" },
+                    "jwtSecret": { "type": "string" }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "agent": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["aiProvider"],
+      "properties": {
+        "replicaCount": { "type": "integer", "minimum": 0 },
+        "image": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "repository": { "type": "string" },
+            "tag": { "type": "string" },
+            "pullPolicy": {
+              "type": "string",
+              "enum": ["Always", "IfNotPresent", "Never"]
+            }
+          },
+          "required": ["repository"]
+        },
+        "service": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": ["ClusterIP", "NodePort", "LoadBalancer", "ExternalName"]
+            },
+            "port": { "type": "integer", "minimum": 1, "maximum": 65535 }
+          }
+        },
+        "containerPort": { "type": "integer", "minimum": 1, "maximum": 65535 },
+        "ingress": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "ingressClassName": { "type": "string" },
+            "annotations": { "type": "object", "additionalProperties": true },
+            "hosts": { "type": "array" },
+            "paths": { "type": "array", "items": { "type": "string" } },
+            "pathType": { "type": "string" },
+            "tls": { "type": "array" }
+          }
+        },
+        "resources": { "type": "object", "additionalProperties": true },
+        "podSecurityContext": { "type": "object", "additionalProperties": true },
+        "securityContext": { "type": "object", "additionalProperties": true },
+        "logLevel": {
+          "type": "string",
+          "enum": ["debug", "info", "warning", "error", "critical"]
+        },
+        "workers": { "type": "integer", "minimum": 1 },
+        "aiProvider": {
+          "type": "string",
+          "enum": ["gemini", "openai", "anthropic"],
+          "description": "STRICT enum. Allowed values: gemini, openai, anthropic. Note the spelling 'anthropic' (not 'antrophic')."
+        },
+        "k8s": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "apiTimeoutSeconds": { "type": "integer", "minimum": 1 },
+            "eventLimit": { "type": "integer", "minimum": 0 },
+            "logTailLines": { "type": "integer", "minimum": 0 }
+          }
+        },
+        "prompt": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "tokenBudget": { "type": "integer", "minimum": 1 },
+            "maxLogLines": { "type": "integer", "minimum": 0 },
+            "maxEvents": { "type": "integer", "minimum": 0 },
+            "summaryMaxItems": { "type": "integer", "minimum": 0 }
+          }
+        },
+        "masking": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "regexList": { "type": "array" },
+            "builtinRedaction": { "type": "boolean" },
+            "builtinRedactionHashMode": { "type": "boolean" }
+          }
+        },
+        "prometheus": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "url": { "type": "string" },
+            "httpTimeoutSeconds": { "type": "integer", "minimum": 1 }
+          }
+        },
+        "tempo": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "url": { "type": "string" },
+            "httpTimeoutSeconds": { "type": "integer", "minimum": 1 },
+            "tenantId": { "type": "string" },
+            "traceLimit": { "type": "integer", "minimum": 0 },
+            "lookbackMinutes": { "type": "integer", "minimum": 0 },
+            "forwardMinutes": { "type": "integer", "minimum": 0 }
+          }
+        },
+        "loki": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "url": { "type": "string" },
+            "httpTimeoutSeconds": { "type": "integer", "minimum": 1 },
+            "tenantId": { "type": "string" }
+          }
+        },
+        "gemini": {
+          "type": "object",
+          "additionalProperties": true,
+          "required": ["modelId"],
+          "properties": {
+            "modelId": { "type": "string", "minLength": 1 },
+            "apiKey": { "type": "string" },
+            "secret": {
+              "type": "object",
+              "additionalProperties": true,
+              "properties": {
+                "create": { "type": "boolean" },
+                "existingSecret": { "type": "string" },
+                "key": { "type": "string" }
+              }
+            }
+          }
+        },
+        "openai": {
+          "type": "object",
+          "additionalProperties": true,
+          "required": ["modelId"],
+          "properties": {
+            "modelId": { "type": "string", "minLength": 1 },
+            "apiKey": { "type": "string" },
+            "secret": {
+              "type": "object",
+              "additionalProperties": true,
+              "properties": {
+                "create": { "type": "boolean" },
+                "existingSecret": { "type": "string" },
+                "key": { "type": "string" }
+              }
+            }
+          }
+        },
+        "anthropic": {
+          "type": "object",
+          "additionalProperties": true,
+          "required": ["modelId"],
+          "properties": {
+            "modelId": { "type": "string", "minLength": 1 },
+            "maxTokens": { "type": "integer", "minimum": 1 },
+            "apiKey": { "type": "string" },
+            "secret": {
+              "type": "object",
+              "additionalProperties": true,
+              "properties": {
+                "create": { "type": "boolean" },
+                "existingSecret": { "type": "string" },
+                "key": { "type": "string" }
+              }
+            }
+          }
+        },
+        "sessionDB": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "host": { "type": "string" },
+            "port": { "type": "integer", "minimum": 1, "maximum": 65535 },
+            "name": { "type": "string" },
+            "user": { "type": "string" },
+            "secret": {
+              "type": "object",
+              "additionalProperties": true,
+              "properties": {
+                "existingSecret": { "type": "string" },
+                "key": { "type": "string" }
+              }
+            }
+          }
+        },
+        "cache": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "size": { "type": "integer", "minimum": 0 },
+            "ttlSeconds": { "type": "integer", "minimum": 0 }
+          }
+        },
+        "retry": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "maxAttempts": { "type": "integer", "minimum": 1 },
+            "minWait": { "type": "number", "minimum": 0 },
+            "maxWait": { "type": "number", "minimum": 0 }
+          }
+        },
+        "nodeSelector": { "type": "object", "additionalProperties": true },
+        "tolerations": { "type": "array" },
+        "affinity": { "type": "object", "additionalProperties": true }
+      }
+    },
+    "frontend": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "replicaCount": { "type": "integer", "minimum": 0 },
+        "image": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "repository": { "type": "string" },
+            "tag": { "type": "string" },
+            "pullPolicy": {
+              "type": "string",
+              "enum": ["Always", "IfNotPresent", "Never"]
+            }
+          },
+          "required": ["repository"]
+        },
+        "service": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": ["ClusterIP", "NodePort", "LoadBalancer", "ExternalName"]
+            },
+            "port": { "type": "integer", "minimum": 1, "maximum": 65535 }
+          }
+        },
+        "containerPort": { "type": "integer", "minimum": 1, "maximum": 65535 },
+        "ingress": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "ingressClassName": { "type": "string" },
+            "annotations": { "type": "object", "additionalProperties": true },
+            "hosts": { "type": "array" },
+            "paths": { "type": "array", "items": { "type": "string" } },
+            "pathType": { "type": "string" },
+            "tls": { "type": "array" }
+          }
+        },
+        "resources": { "type": "object", "additionalProperties": true },
+        "podSecurityContext": { "type": "object", "additionalProperties": true },
+        "securityContext": { "type": "object", "additionalProperties": true },
+        "nodeSelector": { "type": "object", "additionalProperties": true },
+        "tolerations": { "type": "array" },
+        "affinity": { "type": "object", "additionalProperties": true }
+      }
+    },
+    "openapi": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "replicaCount": { "type": "integer", "minimum": 0 },
+        "image": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "repository": { "type": "string" },
+            "tag": { "type": "string" },
+            "pullPolicy": {
+              "type": "string",
+              "enum": ["Always", "IfNotPresent", "Never"]
+            }
+          }
+        },
+        "service": { "type": "object", "additionalProperties": true },
+        "containerPort": { "type": "integer", "minimum": 1, "maximum": 65535 },
+        "baseUrl": { "type": "string" },
+        "ingress": { "type": "object", "additionalProperties": true },
+        "specs": { "type": "object", "additionalProperties": true },
+        "resources": { "type": "object", "additionalProperties": true },
+        "podSecurityContext": { "type": "object", "additionalProperties": true },
+        "securityContext": { "type": "object", "additionalProperties": true },
+        "nodeSelector": { "type": "object", "additionalProperties": true },
+        "tolerations": { "type": "array" },
+        "affinity": { "type": "object", "additionalProperties": true }
+      }
+    },
+    "pgvector": {
+      "type": "object",
+      "additionalProperties": true,
+      "description": "Forward-compatible top-level alias for pgvector configuration. Authoritative pgvector enablement happens via postgresql.primary.initdb.scripts."
+    }
+  }
+}

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -1,0 +1,149 @@
+# KubeRCA FAQ
+
+Frequently asked questions about deploying and operating KubeRCA.
+
+---
+
+## Which AI provider should I choose?
+
+KubeRCA supports three providers via `agent.aiProvider`:
+
+| Provider   | `agent.aiProvider` | Default model              | Cost (rough) | Latency  | Quality | Prompt budget |
+|------------|--------------------|----------------------------|--------------|----------|---------|----------------|
+| Gemini     | `gemini`           | `gemini-3.1-flash-lite-preview` | Lowest       | Fastest  | Good     | Large (~1M)    |
+| OpenAI     | `openai`           | `gpt-5-mini`               | Mid          | Mid      | High     | Mid (~128k+)   |
+| Anthropic  | `anthropic`        | `claude-haiku-4-5`         | Mid          | Mid-low  | Highest tool reasoning | Large (~200k)  |
+
+Rules of thumb:
+
+- **Default / cost-sensitive** -> Gemini (`gemini-3.1-flash-lite-preview` is the recommended runtime baseline; `flash-lite` alone has been observed underperforming on KubeRCA prompts).
+- **Highest quality on long, multi-step traces** -> Anthropic. Bump `agent.anthropic.maxTokens` if you see truncated responses.
+- **Balanced default if your org already standardized on OpenAI** -> OpenAI.
+
+> Note: backend embeddings (similarity search for past incidents) only use Gemini. Even if you switch the agent to OpenAI / Anthropic, you still need a Gemini API key for `backend.embedding.apiKey`.
+
+The provider name must be exactly one of `gemini`, `openai`, `anthropic`. The chart `values.schema.json` rejects other strings, including the common typo `antrophic`.
+
+---
+
+## Is Slack integration required?
+
+**No.** KubeRCA works end-to-end without Slack:
+
+- Alertmanager -> backend webhook still fires
+- Agent still runs analysis
+- Frontend still shows incidents and analyses
+
+Slack is purely an outbound notification + thread-context channel. Disable it with:
+
+```yaml
+backend:
+  slack:
+    enabled: false
+```
+
+If you later want it, set `backend.slack.enabled=true`, fill in `backend.slack.token` and `backend.slack.channelId` (or point to an existing Secret), and `helm upgrade`.
+
+---
+
+## Can I use an external PostgreSQL?
+
+**Yes.** Disable the bundled subchart and point the backend at your own database:
+
+```yaml
+postgresql:
+  enabled: false
+
+externalDatabase:
+  host: "my-rds.cluster-xxxx.us-east-1.rds.amazonaws.com"
+  port: 5432
+  user: "kube-rca"
+  database: "kube-rca"
+  existingSecret: "kube-rca-external-db"   # must contain key 'password'
+
+backend:
+  postgresql:
+    host: "my-rds.cluster-xxxx.us-east-1.rds.amazonaws.com"
+    port: 5432
+    user: "kube-rca"
+    database: "kube-rca"
+    secret:
+      existingSecret: "kube-rca-external-db"
+      key: "password"
+
+agent:
+  sessionDB:
+    host: "my-rds.cluster-xxxx.us-east-1.rds.amazonaws.com"
+    port: 5432
+    name: "kube-rca"
+    user: "kube-rca"
+    secret:
+      existingSecret: "kube-rca-external-db"
+      key: "password"
+```
+
+Make sure the `vector` extension is available on your PostgreSQL — see `docs/TROUBLESHOOTING.md` ("pgvector extension not found").
+
+---
+
+## Does it support multiple clusters?
+
+**Not yet.** Multi-cluster fan-in is on the roadmap (target Q3 2026). The current architecture is single-cluster:
+
+- One Alertmanager -> one KubeRCA backend
+- The backend collects context from the cluster it runs in (via the in-cluster Kubernetes API)
+
+For now, the recommended pattern is one KubeRCA install per cluster, with each install posting to its own Slack channel / OIDC tenant. We track this work under <https://github.com/kube-rca/kuberca/issues> with the `multi-cluster` label.
+
+---
+
+## What happens if Loki / Tempo / Istio are not installed?
+
+KubeRCA treats Loki, Tempo, and Istio as **optional context enrichers**. If their endpoints are not configured, the agent skips them silently and still produces an RCA from Kubernetes events + pod logs + Prometheus metrics:
+
+```yaml
+agent:
+  prometheus:
+    url: ""    # disabled
+  loki:
+    url: ""    # disabled
+  tempo:
+    url: ""    # disabled
+```
+
+When you install one of them later, just set the URL in your values file and `helm upgrade`. No code change is needed in the backend or agent.
+
+Tempo URLs must use the `service.namespace` form (e.g. `tempo.monitoring`) — Tempo does not emit a `k8s.namespace.name` tag, so the agent uses the FQDN to resolve traces.
+
+---
+
+## How are LLM responses masked?
+
+KubeRCA runs a **two-stage masking pipeline** on every prompt and response:
+
+1. **Built-in redaction** (`agent.masking.builtinRedaction: true`, default) — applies a curated denylist of secret-shaped patterns (JWTs, AWS access keys, Bearer tokens, K8s `data.*` blobs, ConfigMap values that look base64-encoded, etc.).
+2. **User regex list** (`agent.masking.regexList`) — your own JSON array of regex patterns to redact.
+
+Optionally, set `agent.masking.builtinRedactionHashMode: true` to replace matches with a deterministic `[HASH:xxx]` token so the same secret produces the same hash across the conversation (useful for correlation without leaking the value).
+
+For the source of truth, see `agent/tests/test_masking.py` in the repo — it doubles as a regression suite for the masking rules.
+
+---
+
+## How do I upgrade?
+
+`helm upgrade` is generally safe between minor versions:
+
+```bash
+helm upgrade kube-rca oci://public.ecr.aws/r5b7j2e4/kube-rca-ecr/charts/kube-rca \
+  -n kube-rca \
+  -f my-values.yaml
+```
+
+Before upgrading, check `CHANGELOG.md` (auto-generated by release-please) for any entries marked **BREAKING CHANGE**. Examples of changes that need extra care:
+
+- Bitnami `postgresql` major version bump (review their migration notes — usually a PVC deletion + restore is *not* required, but read the chart notes)
+- New required values key (the chart's `values.schema.json` will fail-fast and tell you which key is missing)
+- Backend or agent image tag with a database migration — the chart's `wait-for-db` init container handles ordering; you should not need manual SQL
+
+If the upgrade fails partway, `helm rollback kube-rca <previous-revision> -n kube-rca` returns the cluster to the prior state. Backend / agent are stateless except for PostgreSQL; data is preserved across rollbacks.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -1,0 +1,304 @@
+# KubeRCA Troubleshooting
+
+Common installation and runtime issues, ordered roughly from "first install" to "deeper integration."
+
+> Need a fresh install walkthrough first? See `docs/installation-guide-en.md`.
+
+---
+
+## 1. AI provider key not configured
+
+**Symptom**
+
+The agent pod is `Running`, but `/analyze` returns errors like `AI_PROVIDER api key missing`, or analyses never complete and you see `401`/`403` from the LLM provider in agent logs.
+
+**Cause**
+
+`agent.aiProvider` is set, but the matching `agent.<provider>.apiKey` (or `agent.<provider>.secret.existingSecret`) is empty.
+
+**Fix**
+
+Pick one of:
+
+1. **Inline value** (Quick Start only — not recommended for production):
+
+   ```yaml
+   agent:
+     aiProvider: "gemini"   # or "openai" / "anthropic"
+     gemini:
+       apiKey: "AIza..."
+   ```
+
+2. **Existing Secret** (recommended):
+
+   ```yaml
+   agent:
+     aiProvider: "openai"
+     openai:
+       secret:
+         create: false
+         existingSecret: "kube-rca-ai"
+         key: "openai-api-key"
+   ```
+
+   Then create the Secret out-of-band:
+
+   ```bash
+   kubectl -n kube-rca create secret generic kube-rca-ai \
+     --from-literal=openai-api-key="sk-..."
+   ```
+
+The allowed `aiProvider` values are exactly `gemini`, `openai`, `anthropic`. Note the spelling — `anthropic`, not `antrophic`.
+
+---
+
+## 2. `pgvector` extension not found
+
+**Symptom**
+
+Backend pod CrashLoops with logs like `ERROR: type "vector" does not exist` or `extension "vector" is not available`.
+
+**Cause**
+
+The PostgreSQL instance is missing the `vector` extension. By default the bundled Bitnami `postgresql` sub-chart runs an `initdb` script (`enable-pgvector.sh`) that runs `CREATE EXTENSION IF NOT EXISTS vector;` on first boot. If you bring your own database, this never runs.
+
+**Fix**
+
+- **Bundled PostgreSQL**: confirm the chart was installed with default values; you should see `kube-rca-postgresql-0` running. If the volume already existed from a previous install without `pgvector`, delete the PVC and reinstall:
+
+  ```bash
+  helm uninstall kube-rca -n kube-rca
+  kubectl delete pvc -n kube-rca -l app.kubernetes.io/name=postgresql
+  helm upgrade --install kube-rca ... # reinstall
+  ```
+
+- **External PostgreSQL** (`postgresql.enabled=false`): connect as a superuser and run:
+
+  ```sql
+  CREATE EXTENSION IF NOT EXISTS vector;
+  ```
+
+  Make sure the PostgreSQL build has the `pgvector` extension installed at the OS level (some managed databases need to enable it via the cloud console first — for example, RDS requires `rds.allowed_extensions` to include `vector`).
+
+---
+
+## 3. Slack messages not posting
+
+**Symptom**
+
+Alerts arrive at the backend (`/webhook/alertmanager` returns 200) but no message appears in Slack. Backend logs show `slack: not_authed`, `invalid_auth`, or `channel_not_found`.
+
+**Cause**
+
+One of:
+
+- `backend.slack.enabled` is `false`
+- `backend.slack.token` (or the Secret it references) is empty / wrong
+- Bot lacks `chat:write` and/or `channels:read` scopes
+- Channel ID is invalid or the bot has not been invited to the channel
+
+**Fix**
+
+1. Confirm the Slack token is set:
+
+   ```bash
+   kubectl -n kube-rca get secret kube-rca-slack -o jsonpath='{.data.kube-rca-slack-token}' | base64 -d
+   ```
+
+2. In Slack, open your app config and verify the OAuth scopes:
+   - `chat:write` (post messages)
+   - `channels:read` (look up the channel)
+
+3. Invite the bot to the target channel:
+
+   ```
+   /invite @your-kube-rca-bot
+   ```
+
+4. Confirm `channelId` is the **channel ID** (e.g. `C12345ABCDE`) — not the human-readable name.
+
+---
+
+## 4. OIDC `redirect_uri` mismatch
+
+**Symptom**
+
+Google/Okta login fails with `Error 400: redirect_uri_mismatch`, or the user lands back at the login page after authenticating.
+
+**Cause**
+
+`backend.auth.oidc.redirectUri` does not match any redirect URI registered in your OIDC provider console.
+
+**Fix**
+
+The backend always uses `<frontend-host>/api/v1/auth/oidc/callback` as the callback path. Both sides must agree:
+
+- **Helm values**:
+
+  ```yaml
+  backend:
+    auth:
+      oidc:
+        enabled: true
+        issuer: "https://accounts.google.com"
+        redirectUri: "https://kube-rca.example.com/api/v1/auth/oidc/callback"
+  ```
+
+- **Google Cloud Console** -> APIs & Services -> Credentials -> Authorized redirect URIs:
+  - `https://kube-rca.example.com/api/v1/auth/oidc/callback`
+
+The host, scheme, and path must match exactly. After editing, `helm upgrade` and re-trigger login.
+
+---
+
+## 5. `ImagePullBackOff` on KubeRCA images
+
+**Symptom**
+
+Pods stuck in `ImagePullBackOff`. `kubectl describe pod` shows errors pulling from `public.ecr.aws/r5b7j2e4/kube-rca-ecr/...`.
+
+**Cause**
+
+ECR Public *does* allow anonymous pulls — no credentials needed. So this is almost always a node-side networking or DNS issue:
+
+- The cluster cannot reach `public.ecr.aws` (egress firewall, NAT gateway, no IPv4 route)
+- Region-restricted egress policy blocks `*.amazonaws.com`
+- Stale image cache after an image tag was force-pushed (rare)
+
+**Fix**
+
+1. From a debug pod inside the cluster:
+
+   ```bash
+   kubectl run --rm -it --image=alpine:3 net-debug -- sh
+   apk add --no-cache curl
+   curl -sI https://public.ecr.aws/v2/
+   ```
+
+   You should get a 401 (challenge) — that proves DNS + TLS work.
+
+2. If your nodes are in a private subnet, confirm the NAT gateway / VPC endpoint route is healthy.
+
+3. Verify the tag actually exists:
+
+   ```bash
+   docker pull public.ecr.aws/r5b7j2e4/kube-rca-ecr/backend:backend-0.5.1
+   ```
+
+---
+
+## 6. `CrashLoopBackOff` on backend startup
+
+**Symptom**
+
+`kube-rca-backend` keeps restarting. Logs show `dial tcp: connection refused` or `pq: SSL is not enabled on the server` immediately after pod start.
+
+**Cause**
+
+Backend is starting before PostgreSQL is reachable, or the password Secret is wrong.
+
+**Fix**
+
+1. Confirm the `wait-for-db` init container is enabled (default is `true`):
+
+   ```yaml
+   backend:
+     waitForDb:
+       enabled: true
+   ```
+
+2. Confirm the password key matches:
+
+   ```yaml
+   backend:
+     postgresql:
+       secret:
+         existingSecret: "postgresql"
+         key: "password"
+   ```
+
+3. Inspect the postgresql Secret:
+
+   ```bash
+   kubectl -n kube-rca get secret postgresql -o jsonpath='{.data}' | jq 'keys'
+   ```
+
+4. Tune retries if your DB is slow to become ready (e.g. cold-started RDS Aurora):
+
+   ```yaml
+   backend:
+     postgresql:
+       retry:
+         maxAttempts: 30
+         maxBackoffSeconds: 60
+   ```
+
+---
+
+## 7. Agent `/analyze` times out
+
+**Symptom**
+
+The backend marks the alert as analyzed late (or as failed). Agent logs show requests still running past 120 seconds.
+
+**Cause**
+
+The default backend->agent timeout is 120 seconds. Long LLM calls (especially `claude-haiku-4-5` on a long context, or a slow Tempo trace search) can exceed it.
+
+**Fix**
+
+- **Backend side** — bump the agent timeout via env on the backend Deployment (set the `AGENT_TIMEOUT` env in your values override or via a custom patch).
+- **Agent side** — give the agent more headroom:
+
+  ```yaml
+  agent:
+    resources:
+      requests:
+        cpu: 500m
+        memory: 512Mi
+      limits:
+        cpu: 2
+        memory: 1Gi
+    prompt:
+      tokenBudget: 16000     # cut prompt size
+      maxLogLines: 15
+      maxEvents: 15
+  ```
+
+- **Provider side** — lower `agent.anthropic.maxTokens`, or switch to a faster model (e.g. `gemini-3.1-flash-lite-preview`).
+
+If you have **Loki** or **Tempo** integrated, also confirm those endpoints are reachable; the agent waits on each enricher up to its `httpTimeoutSeconds` setting. Optional enrichers degrade gracefully when their `url` is empty.
+
+---
+
+## 8. Webhook returns `401 Unauthorized`
+
+**Symptom**
+
+After upgrading to a future release with HMAC webhook validation enabled, Alertmanager logs show `401 Unauthorized` from `POST /webhook/alertmanager`.
+
+**Cause**
+
+Inbound HMAC validation is gated on a future release (W2). When that lands, the backend will reject webhook calls whose `X-KubeRCA-Signature` header is missing or wrong.
+
+**Fix**
+
+When the feature ships:
+
+1. Set a shared secret on the backend:
+
+   ```yaml
+   webhookSecret: "$(openssl rand -hex 32)"
+   ```
+
+2. Configure Alertmanager to sign webhook payloads with the same secret (Alertmanager doesn't do HMAC natively today; pair with a small relay such as the planned `kube-rca-webhook-proxy`, or temporarily disable validation by leaving `webhookSecret` unset).
+
+Until that release, the webhook accepts any request that matches the Alertmanager payload schema. Restrict access at the network layer (e.g. NetworkPolicy or service mesh policy) in the meantime.
+
+---
+
+## Still stuck?
+
+- Pull pod logs: `kubectl -n kube-rca logs deploy/kube-rca-backend --tail=200`
+- Tail agent logs while triggering an alert: `kubectl -n kube-rca logs -f deploy/kube-rca-agent`
+- Open an issue with logs and your `helm get values kube-rca -n kube-rca`: <https://github.com/kube-rca/kuberca/issues>

--- a/docs/installation-guide-en.md
+++ b/docs/installation-guide-en.md
@@ -1,0 +1,270 @@
+# KubeRCA Installation Guide
+
+A guide to installing KubeRCA, an alert-driven Root Cause Analysis (RCA) tool for Kubernetes, and running your first demo.
+
+---
+
+## Prerequisites
+
+| Item | Minimum requirement |
+|------|---------------------|
+| Kubernetes | v1.32 or later |
+| Helm | v3.x |
+| kubectl | Connected to the target cluster |
+| AI API Key | [Google AI Studio API Key](https://aistudio.google.com/apikey) (recommended; usable for both analysis and embeddings) |
+
+### Cluster resources
+
+| Component | CPU (request) | Memory (request) | Notes |
+|-----------|--------------|-------------------|-------|
+| Backend | 100m | 128Mi | Go server |
+| Agent | 200m | 256Mi | Python FastAPI + LLM calls |
+| Frontend | 50m | 64Mi | Nginx static serving |
+| PostgreSQL | 250m | 256Mi | Includes pgvector |
+| **Total** | **~600m** | **~704Mi** | Minimum baseline; tune for production |
+
+> **Note:** The values above are the minimum to make the chart run. Tune `resources.requests` / `resources.limits` in your values file for production workloads.
+
+### Pre-flight checks
+
+```bash
+# Check Kubernetes version
+kubectl version --short
+
+# Check Helm version
+helm version --short
+```
+
+---
+
+## Install (under 5 minutes)
+
+### Step 1: Create a values file
+
+Create a `my-values.yaml` file:
+
+```yaml
+# PostgreSQL — the chart auto-creates the Secret
+postgresql:
+  auth:
+    existingSecret: ""          # let the bitnami subchart manage the Secret
+    password: "change-me"       # set the DB password
+
+# Backend
+backend:
+  slack:
+    enabled: false              # disable Slack for the Quick Start
+  postgresql:
+    secret:
+      existingSecret: ""        # bitnami auto-reference
+  embedding:
+    apiKey:
+      existingSecret: ""        # share the agent's AI key Secret
+
+# Agent — AI provider and API key
+agent:
+  aiProvider: "gemini"          # gemini | openai | anthropic
+  gemini:
+    apiKey: "PASTE_YOUR_API_KEY_HERE"
+    secret:
+      existingSecret: ""        # apiKey value triggers Secret creation
+
+# Frontend — accessed via port-forward (configure Ingress separately for production)
+```
+
+> **Using a different AI provider:**
+>
+> | Provider | `agent.aiProvider` | apiKey field |
+> |----------|--------------------|--------------|
+> | Gemini (default) | `"gemini"` | `agent.gemini.apiKey` |
+> | OpenAI | `"openai"` | `agent.openai.apiKey` |
+> | Anthropic | `"anthropic"` | `agent.anthropic.apiKey` |
+>
+> **Heads up:** The backend embedding feature currently **only supports Gemini**. Even if you run the agent on OpenAI or Anthropic, you still need a separate Gemini API key for embeddings.
+
+### Step 2: Install with Helm
+
+```bash
+helm upgrade --install kube-rca oci://public.ecr.aws/r5b7j2e4/kube-rca-ecr/charts/kube-rca \
+  -n kube-rca --create-namespace \
+  -f my-values.yaml
+```
+
+### Step 3: Verify the install
+
+```bash
+kubectl get pods -n kube-rca -w
+```
+
+**The install is successful when every pod is `Running`:**
+
+```
+NAME                                READY   STATUS    RESTARTS   AGE
+kube-rca-backend-xxxxxxxxxx-xxxxx   1/1     Running   0          2m
+kube-rca-agent-xxxxxxxxxx-xxxxx     1/1     Running   0          2m
+kube-rca-frontend-xxxxxxxxxx-xxxxx  1/1     Running   0          2m
+kube-rca-postgresql-0               1/1     Running   0          2m
+```
+
+Backend health check:
+
+```bash
+kubectl port-forward svc/kube-rca-backend 8080:8080 -n kube-rca &
+curl http://localhost:8080/ping
+# Response: {"message":"pong"}
+```
+
+### Step 4: Access the UI
+
+```bash
+# Terminal 1 — Frontend
+kubectl port-forward svc/kube-rca-frontend 3000:80 -n kube-rca
+
+# Terminal 2 — Backend (needed for the frontend's API calls)
+kubectl port-forward svc/kube-rca-backend 8080:8080 -n kube-rca
+```
+
+Open `http://localhost:3000` in your browser to see the login screen.
+
+| Field | Default |
+|-------|---------|
+| ID | `kube-rca` |
+| Password | `kube-rca` |
+
+> Always change `backend.auth.admin.username` and `backend.auth.admin.password` for production.
+
+---
+
+## Uninstall
+
+```bash
+# Remove KubeRCA
+helm uninstall kube-rca -n kube-rca
+
+# Remove the PostgreSQL PVC and namespace (deletes all data)
+kubectl delete pvc -n kube-rca -l app.kubernetes.io/name=postgresql
+kubectl delete namespace kube-rca
+```
+
+---
+
+## First scenario: OOMKilled root-cause analysis (under 10 minutes)
+
+A demo you can run right after install. It triggers an OOMKilled pod and watches KubeRCA perform Root Cause Analysis automatically.
+
+### Preconditions
+
+- KubeRCA install complete (steps above)
+- Alertmanager wired to the KubeRCA webhook
+
+### Step 1: Wire up Alertmanager
+
+KubeRCA only receives alerts when Alertmanager has a webhook receiver configured.
+
+**With kube-prometheus-stack** (add to your Helm values):
+
+```yaml
+alertmanager:
+  config:
+    receivers:
+      - name: "kube-rca"
+        webhook_configs:
+          - url: "http://kube-rca-backend.kube-rca.svc.cluster.local:8080/webhook/alertmanager"
+            send_resolved: true
+    route:
+      receiver: "kube-rca"
+```
+
+**With a standalone Alertmanager** (add to `alertmanager.yml`):
+
+```yaml
+receivers:
+  - name: "kube-rca"
+    webhook_configs:
+      - url: "http://kube-rca-backend.kube-rca.svc.cluster.local:8080/webhook/alertmanager"
+        send_resolved: true
+
+route:
+  receiver: "kube-rca"
+```
+
+### Step 2: Inject an OOMKilled failure
+
+Deploy a pod with an aggressively low memory limit:
+
+```bash
+kubectl create namespace demo-oom 2>/dev/null || true
+
+kubectl apply -n demo-oom -f - <<'EOF'
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: memory-hog
+  labels:
+    app: memory-hog
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: memory-hog
+  template:
+    metadata:
+      labels:
+        app: memory-hog
+    spec:
+      containers:
+        - name: stress
+          image: polinux/stress:1.0.4
+          command: ["stress"]
+          args: ["--vm", "1", "--vm-bytes", "128M", "--vm-hang", "1"]
+          resources:
+            requests:
+              memory: "32Mi"
+            limits:
+              memory: "64Mi"    # allocates 128M -> OOMKilled
+EOF
+```
+
+### Step 3: Observe the failure
+
+```bash
+# Pod state (will show OOMKilled or CrashLoopBackOff)
+kubectl get pods -n demo-oom -w
+```
+
+Within roughly 30 seconds to 1 minute, the pod transitions to `OOMKilled` -> `CrashLoopBackOff`.
+
+### Step 4: Inspect the KubeRCA analysis
+
+When Alertmanager fires `KubeOOMKilled` or `KubePodCrashLooping`, KubeRCA automatically:
+
+1. Collects Kubernetes events, pod logs, and resource state
+2. Runs Root Cause Analysis through the LLM
+3. Persists the analysis result
+
+In the browser, open `http://kube-rca.local` and:
+
+- Find the new alert in the **Incidents** list
+- Click the alert to view the **RCA analysis** and **remediation guide**
+
+### Step 5: Clean up
+
+```bash
+kubectl delete namespace demo-oom
+```
+
+---
+
+## Next steps
+
+To take KubeRCA to production:
+
+- Manage AI API keys via ExternalSecrets / SealedSecrets
+- Enable Slack integration (`backend.slack.enabled: true`)
+- Configure OIDC (Google, Okta, GitHub, etc.)
+- Wire in Prometheus / Loki / Tempo for richer context collection
+- Tune resource requests / limits
+
+For the full set of Helm values and detailed configuration, see the [Helm Chart README](https://github.com/kube-rca/kuberca/blob/main/charts/kube-rca/README.md).
+
+**For production rollouts and technical support, reach out at [contact@cloudbro.ai](mailto:contact@cloudbro.ai).**

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -38,3 +38,10 @@ EXPOSE 80
 # Start nginx
 CMD ["nginx", "-g", "daemon off;"]
 
+LABEL org.opencontainers.image.source="https://github.com/kube-rca/kuberca"
+LABEL org.opencontainers.image.licenses="Apache-2.0"
+LABEL org.opencontainers.image.description="KubeRCA Frontend"
+LABEL org.opencontainers.image.documentation="https://github.com/kube-rca/kuberca/tree/main/frontend"
+LABEL org.opencontainers.image.vendor="KubeRCA"
+LABEL org.opencontainers.image.title="KubeRCA frontend"
+


### PR DESCRIPTION
## Summary

Three discoverability + distribution improvements for the OSS launch:

1. **Helm chart discovery** — Artifact Hub annotations, JSON Schema validation for \`values.yaml\`, Apache 2.0 NOTICE.
2. **Image provenance** — OCI labels on backend / frontend / agent Dockerfiles so \`docker inspect\` surfaces source, license, vendor, documentation.
3. **English documentation parity** — full English installation guide, FAQ, and troubleshooting guide; ReDoc-published OpenAPI reference via GitHub Pages.

Depends conceptually on \`ai/orchestrator/relicense-apache2\` (W0) — references Apache 2.0 in chart annotations and OCI labels. Merge W0 first.

## Changes (4 commits)

### 1. \`chore(charts): add Artifact Hub annotations and values.schema.json\`
- \`charts/kube-rca/Chart.yaml\` — \`artifacthub.io/{category,license,links,maintainers,changes}\` so the chart shows up well on https://artifacthub.io once registered.
- \`charts/kube-rca/values.schema.json\` — JSON Schema (draft-07) covering \`image\`, \`ingress\`, \`agent.aiProvider\` (strict enum: \`gemini|openai|anthropic\` — guards against the historical \`antrophic\` typo), per-provider \`modelId\` required, \`oidc.existingSecret.keys\` required keys, \`pgvector\`, \`persistence\`, \`webhookSecret\` placeholder for future W2.
- \`charts/kube-rca/NOTICE\` — Apache 2.0 attribution for chart distribution.

### 2. \`chore(docker): add OCI labels (Apache-2.0)\`
- \`backend/Dockerfile\`, \`frontend/Dockerfile\`, \`agent/Dockerfile\` — \`org.opencontainers.image.{source,licenses,description,documentation,vendor,title}\`. Labels placed at the END of the final stage so existing layer cache is unaffected.

### 3. \`docs: add English installation guide, FAQ, troubleshooting\`
- \`docs/installation-guide-en.md\` — structurally 1:1 with the Korean original.
- \`docs/TROUBLESHOOTING.md\` — covers AI provider key, pgvector extension, Slack token, OIDC redirect, ImagePullBackOff, CrashLoopBackOff, agent timeout, webhook 401 (forward-reference to W2 HMAC).
- \`docs/FAQ.md\` — provider selection, optional Slack, external PostgreSQL, multi-cluster (roadmap), graceful degradation when Loki/Tempo/Istio not installed, masking pipeline, upgrade path.

### 4. \`ci(docs): add ReDoc GitHub Pages workflow\`
- \`.github/workflows/redoc-pages.yaml\` — builds a single static HTML from \`backend/docs/swagger.yaml\` and publishes to \`gh-pages\`. Trigger: push to main on swagger changes + manual workflow_dispatch.
- Action pinning uses stable version tags; SHA pinning is intentionally deferred to W2 supply-chain workstream.

## Stats

10 files changed, +1563

## Test plan

- [x] \`helm lint charts/kube-rca\` — passes (after \`helm repo add bitnami\` + \`helm dependency build\`)
- [x] \`helm template kube-rca charts/kube-rca\` — 855 lines (default) and 1129 lines (production override) render without error
- [x] \`jq empty values.schema.json\` — valid JSON
- [x] \`helm install --dry-run --set agent.aiProvider=antrophic\` — schema correctly rejects with enum error
- [x] All 3 Dockerfiles still parse cleanly

## Post-merge action items (cannot be automated)

- [ ] Register chart on Artifact Hub once chart-OCI signing is in place (W2)
- [ ] Configure GitHub Pages source = \`gh-pages\` branch / \`/api\` path (or whatever the workflow publishes to) once the first \`redoc-pages.yaml\` run succeeds

## Recommended merge order

1. \`ai/orchestrator/relicense-apache2\` (W0)
2. \`ai/orchestrator/oss-governance\` (W1a)
3. **This PR (W1b)**