### PR TITLE
chore!: relicense to Apache-2.0

### DIFF
--- a/.github/RELICENSE_CONSENT.md
+++ b/.github/RELICENSE_CONSENT.md
@@ -1,0 +1,91 @@
+# Relicense Consent: MIT to Apache License 2.0
+
+KubeRCA is being relicensed from the MIT License to the Apache License,
+Version 2.0. This document tracks contributor consent for that change.
+
+## Why we are relicensing
+
+- **CNCF ecosystem alignment** — Apache 2.0 is the de facto license across the
+  CNCF Kubernetes ecosystem (Kubernetes, Prometheus, Istio, Argo CD, etc.).
+  Aligning with our peers reduces friction for downstream integrators.
+- **Explicit patent grant + retaliation clause** — Section 3 of Apache 2.0
+  grants an explicit patent license to all contributors and includes a patent
+  retaliation clause. MIT is silent on patents, which leaves users exposed.
+- **Enterprise legal acceptance** — Apache 2.0 is on the allowlist of nearly
+  every corporate open source policy. MIT is too, but Apache 2.0 ships with
+  the patent and trademark protections enterprise legal teams expect.
+- **Project maturity** — KubeRCA has 4 human contributors today, which makes
+  consent collection tractable. Doing it now is far cheaper than later.
+
+## What this changes
+
+- The repository's [`LICENSE`](../LICENSE) is replaced with the verbatim
+  Apache License, Version 2.0 text.
+- A [`NOTICE`](../NOTICE) file is added at the repository root, as required
+  by Apache 2.0 Section 4(d).
+- All future contributions to KubeRCA are made under Apache License 2.0,
+  per Section 5 (Submission of Contributions) of the new license.
+- Existing forks must update their `LICENSE` references when picking up
+  changes from `main` after this relicense lands.
+
+## How to give consent
+
+You can record your consent in any of the following ways:
+
+1. **Comment on the relicense PR** — A simple "I consent to relicensing my
+   prior contributions to KubeRCA under Apache License 2.0." reply on the
+   PR is sufficient.
+2. **Sign-off on a follow-up commit** — Include
+   `Signed-off-by: Your Name <email>` on a commit that explicitly references
+   this relicense. The commit body should state your consent.
+3. **DCO trailer on a future PR** — A `Signed-off-by:` trailer on any PR
+   merged after this document lands implies acceptance of the current
+   project license (Apache 2.0). New contributors are covered automatically.
+4. **GitHub Discussion** — Open or reply on the relicense Discussion thread
+   in the [`kube-rca/kuberca`](https://github.com/kube-rca/kuberca) repo.
+
+If none of those work for you, DM the project lead (see contact below) and
+we will record your consent manually with a link back to the message.
+
+## Contact
+
+- **Project lead**: KKamJi (Ethan)
+- **Preferred channel**: Open a GitHub Discussion in
+  [`kube-rca/kuberca`](https://github.com/kube-rca/kuberca/discussions) and
+  tag the relicense topic.
+- **Alternate**: PR comment on the relicense PR.
+
+## Contributor checklist
+
+The following identities appear in `git log` history on `main` as of the
+relicense PR. Each unique `Name <email>` pair gets its own checkbox so we
+can track consent precisely. Bot accounts (`dependabot[bot]`,
+`github-actions[bot]`) do not require consent because their commits are
+either trivial automation or carry no human authorship.
+
+Some humans authored commits under multiple email addresses; those
+identities will be consolidated and consent recorded once per person, but
+they are listed separately here for traceability.
+
+### Humans (consent required)
+
+- [ ] binhao &lt;binhao@naver.com&gt;
+- [ ] binhao &lt;binhao@neowiz.com&gt;
+- [ ] binhao22 &lt;binhao@naver.com&gt;
+- [ ] Binoo &lt;73528043+binhao22@users.noreply.github.com&gt;
+- [ ] Brilly-Bohyun &lt;102973953+Brilly-Bohyun@users.noreply.github.com&gt;
+- [ ] hjk1996 &lt;dunhill741@naver.com&gt;
+- [ ] KKamJi &lt;xowl5460@naver.com&gt;
+- [ ] KKamJi98 &lt;72260110+KKamJi98@users.noreply.github.com&gt;
+
+### Bots (no consent required)
+
+- [x] dependabot[bot] &lt;49699333+dependabot[bot]@users.noreply.github.com&gt; — automated dependency bumps, no human authorship
+- [x] github-actions[bot] &lt;41898282+github-actions[bot]@users.noreply.github.com&gt; — release-please / CI commits, no human authorship
+
+## Reference
+
+- [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
+- [Repository `LICENSE`](../LICENSE)
+- [Repository `NOTICE`](../NOTICE)
+- [Apache Software Foundation FAQ on relicensing](https://www.apache.org/legal/resolved.html)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### BREAKING
+
+- Relicensed from MIT to Apache License 2.0. Existing forks must update their LICENSE references. Contributor consent for this change tracked in `.github/RELICENSE_CONSENT.md`. (#<TBD-PR-number>)
+
 ## 1.0.0 (2026-04-05)
 
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,202 @@
-MIT License
 
-Copyright (c) 2025 KubeRCA
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+   1. Definitions.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,11 @@
+KubeRCA
+Copyright 2026 KubeRCA contributors.
+
+This product includes software developed by the KubeRCA project
+(https://github.com/kube-rca/kuberca).
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0


### PR DESCRIPTION
## Summary

Relicense KubeRCA from MIT to **Apache License, Version 2.0**.

Why now:
- CNCF ecosystem alignment — Kubernetes, Prometheus, Helm, Istio, Argo CD all use Apache 2.0; this opens a future CNCF Sandbox path.
- Explicit patent grant + retaliation — defends both contributors and operators in the LLM/AI space.
- Best enterprise legal acceptance.
- Lowest cost-of-change moment: 4 contributors today, very small change set.

## Changes

- \`LICENSE\` — replaced MIT with verbatim Apache 2.0 (202 lines, byte-for-byte canonical text)
- \`NOTICE\` — new file, required by Apache 2.0 attribution
- \`CHANGELOG.md\` — \`## Unreleased\` section with a \`### BREAKING\` bullet
- \`.github/RELICENSE_CONSENT.md\` — contributor consent tracker

Out of scope (separate PRs):
- README badge / Apache 2.0 references → \`ai/orchestrator/oss-governance\`
- Chart \`artifacthub.io/license\` / Dockerfile \`org.opencontainers.image.licenses\` → \`ai/helm-engineer/discovery\`

## Required before merge

- [ ] All listed contributors have recorded consent in \`.github/RELICENSE_CONSENT.md\` (Maintainers track this on the document)

## Recommended merge order

1. **This PR (W0)**
2. \`ai/orchestrator/oss-governance\` (W1a)
3. \`ai/helm-engineer/discovery\` (W1b)

## Test plan

- [x] LICENSE byte-for-byte matches https://www.apache.org/licenses/LICENSE-2.0.txt
- [x] NOTICE present with copyright + license reference
- [x] No code, README, Chart.yaml, or Dockerfile changes in this PR
- [ ] Contributors have signed off (tracked in RELICENSE_CONSENT.md)

## Notes

This is a hard-stop dependency for the OSS hardening initiative. Subsequent PRs assume Apache 2.0 in their text and metadata. After merge, please:
- Enable GitHub private vulnerability reporting if not already on
- Confirm repo topics (\`kubernetes\`, \`rca\`, \`incident-response\`, \`alertmanager\`, \`llm\`, \`oss\`, \`sre\`, \`pgvector\`, \`observability\`)
- Enable Discussions