### PR TITLE
fix(ci): bump trivy-action to v0.36.0 (setup-trivy v0.2.1 missing)

### DIFF
--- a/.github/workflows/publish-image.yaml
+++ b/.github/workflows/publish-image.yaml
@@ -173,7 +173,7 @@ jobs:
           push-to-registry: true
 
       - name: Trivy vulnerability scan
-        uses: aquasecurity/trivy-action@915b19bbe73b92a6cf82a1bc12b087c9a19a5fe2 # v0.28.0
+        uses: aquasecurity/trivy-action@a9c7b0f06e461e9d4b4d1711f154ee024b8d7ab8 # v0.36.0
         with:
           image-ref: ${{ steps.refs.outputs.ecr_image }}
           severity: CRITICAL,HIGH


### PR DESCRIPTION
## Summary

The W2 supply-chain hardening (#14) pinned \`aquasecurity/trivy-action@v0.28.0\`, but that release transitively depends on \`aquasecurity/setup-trivy@v0.2.1\`. Aquasecurity has since removed older setup-trivy tags — only v0.2.6 is published today — so every release-please run on main currently fails with:

\`\`\`
Unable to resolve action \`aquasecurity/setup-trivy@v0.2.1\`, unable to find version \`v0.2.1\`
\`\`\`

This blocks all post-merge image publishes.

## Change

Bump \`aquasecurity/trivy-action\` to v0.36.0 (\`a9c7b0f\`) which references the live setup-trivy v0.2.6. SHA pinning is preserved with the version comment.

## Test plan

- [x] Verified \`a9c7b0f06e461e9d4b4d1711f154ee024b8d7ab8\` is the current v0.36.0 release SHA via \`gh api repos/aquasecurity/trivy-action/git/refs/tags\`
- [x] \`actionlint\`-equivalent YAML parse OK
- [ ] Post-merge: confirm next release-please run no longer fails on the action download step