### PR TITLE
fix(deps): bump python-dotenv to >=1.2.2 (CVE)

### DIFF
--- a/agent/uv.lock
+++ b/agent/uv.lock
@@ -1215,11 +1215,11 @@ wheels = [
 
 [[package]]
 name = "python-dotenv"
-version = "1.2.1"
+version = "1.2.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f0/26/19cadc79a718c5edbec86fd4919a6b6d3f681039a2f6d66d14be94e75fb9/python_dotenv-1.2.1.tar.gz", hash = "sha256:42667e897e16ab0d66954af0e60a9caa94f0fd4ecf3aaf6d2d260eec1aa36ad6", size = 44221, upload-time = "2025-10-26T15:12:10.434Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/14/1b/a298b06749107c305e1fe0f814c6c74aea7b2f1e10989cb30f544a1b3253/python_dotenv-1.2.1-py3-none-any.whl", hash = "sha256:b81ee9561e9ca4004139c6cbba3a238c32b03e4894671e181b671e8cb8425d61", size = 21230, upload-time = "2025-10-26T15:12:09.109Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Resolve the Dependabot medium-severity advisory for \`python-dotenv\`.

- Vulnerable: \`< 1.2.2\` (transitive dep in \`agent/uv.lock\`)
- Fixed in: \`1.2.2\`

## Change

- \`agent/uv.lock\` — \`python-dotenv\` resolved version \`1.2.1\` → \`1.2.2\`
- \`agent/pyproject.toml\` — **unchanged** (python-dotenv is transitive, no direct pin)

No source code under \`agent/app/\` is touched. \`uv lock --upgrade-package python-dotenv\` was used so unrelated packages stay locked.

## Verification

- [x] \`uv lock --check\` — clean (88 packages resolved)
- [x] \`uv run ruff check app tests\` — clean
- [x] \`uv run --extra dev pytest\` — 165 passed in 13.92s
- [x] \`grep python-dotenv agent/uv.lock\` — \`version = "1.2.2"\` confirmed