### PR TITLE
fix(agent): sanitize user-controlled values in logger calls (CodeQL py/log-injection)

### DIFF
--- a/agent/app/api/config.py
+++ b/agent/app/api/config.py
@@ -12,6 +12,7 @@ from app.core.dependencies import (
     get_chat_service,
     get_settings,
 )
+from app.core.log_sanitize import sanitize_log
 
 logger = logging.getLogger(__name__)
 
@@ -29,8 +30,8 @@ async def update_ai_config(request: AIConfigUpdateRequest):
 
     logger.info(
         "Updating AI config: provider=%s, model_id=%s",
-        request.provider,
-        request.model_id,
+        sanitize_log(request.provider),
+        sanitize_log(request.model_id),
     )
 
     # 1. 환경변수 덮어쓰기 (다음 Settings 로드 시 반영)

--- a/agent/app/clients/llm_providers/factory.py
+++ b/agent/app/clients/llm_providers/factory.py
@@ -12,6 +12,7 @@ from app.clients.llm_providers.base import (
     StrandsModel,
 )
 from app.core.config import DEFAULT_ANTHROPIC_MAX_TOKENS, Settings
+from app.core.log_sanitize import sanitize_log
 
 logger = logging.getLogger(__name__)
 
@@ -128,7 +129,9 @@ def get_provider_config(settings: Settings) -> ModelConfig | None:
         api_key = settings.anthropic_api_key
         model_id = settings.anthropic_model_id or DEFAULT_MODEL_IDS[LLMProvider.ANTHROPIC]
     else:
-        logger.warning("Unknown AI provider '%s', falling back to gemini", provider_str)
+        logger.warning(
+            "Unknown AI provider '%s', falling back to gemini", sanitize_log(provider_str)
+        )
         api_key = settings.gemini_api_key
         provider_str = "gemini"
         model_id = settings.gemini_model_id or DEFAULT_MODEL_IDS[LLMProvider.GEMINI]
@@ -136,23 +139,19 @@ def get_provider_config(settings: Settings) -> ModelConfig | None:
     if not api_key:
         logger.warning(
             "No API key configured for provider '%s'. Analysis engine will be disabled.",
-            provider_str,
+            sanitize_log(provider_str),
         )
         return None
 
     try:
         provider = LLMProvider.from_string(provider_str)
     except ValueError:
-        logger.error("Invalid provider: %s", provider_str)
+        logger.error("Invalid provider: %s", sanitize_log(provider_str))
         return None
 
     return ModelConfig(
         provider=provider,
         model_id=model_id,
         api_key=api_key,
-        max_tokens=(
-            settings.anthropic_max_tokens
-            if provider == LLMProvider.ANTHROPIC
-            else None
-        ),
+        max_tokens=(settings.anthropic_max_tokens if provider == LLMProvider.ANTHROPIC else None),
     )

--- a/agent/app/clients/strands_agent.py
+++ b/agent/app/clients/strands_agent.py
@@ -46,6 +46,7 @@ from app.clients.prometheus import PrometheusClient
 from app.clients.session_repository import PostgresSessionRepository
 from app.clients.tempo import TempoClient, build_traceql_query
 from app.core.config import Settings
+from app.core.log_sanitize import sanitize_log
 from app.core.masking import Masker, RegexMasker
 
 logger = logging.getLogger(__name__)
@@ -686,7 +687,7 @@ class StrandsAnalysisEngine:
                 "llm_retry_max_attempts=%d, llm_retry_total_timeout=%.1f, "
                 "llm_retry_max_wait=%.1f",
                 model_config.provider.value,
-                model_config.model_id,
+                sanitize_log(model_config.model_id),
                 self._retry_max_attempts,
                 self._retry_total_timeout,
                 self._retry_max_wait,
@@ -707,7 +708,7 @@ class StrandsAnalysisEngine:
             logger.warning(
                 "chat_session_recovery_started "
                 "session_id=%s error_type=%s expected_manager=%s found_manager=%s",
-                session_id,
+                sanitize_log(session_id),
                 type(exc).__name__,
                 expected_manager,
                 found_manager or "unknown",
@@ -720,7 +721,7 @@ class StrandsAnalysisEngine:
                 logger.exception(
                     "chat_session_recovery_failed "
                     "session_id=%s expected_manager=%s found_manager=%s",
-                    session_id,
+                    sanitize_log(session_id),
                     expected_manager,
                     found_manager or "unknown",
                 )
@@ -729,7 +730,7 @@ class StrandsAnalysisEngine:
             logger.info(
                 "chat_session_recovery_succeeded "
                 "session_id=%s expected_manager=%s found_manager=%s",
-                session_id,
+                sanitize_log(session_id),
                 expected_manager,
                 found_manager or "unknown",
             )
@@ -740,7 +741,7 @@ class StrandsAnalysisEngine:
         logger.warning(
             "gemini_turn_order_recovery session_id=%s — "
             "sanitization in _invoke_with_retry failed, resetting session",
-            session_id,
+            sanitize_log(session_id),
         )
         self._reset_session_state(session_id)
         try:
@@ -748,10 +749,13 @@ class StrandsAnalysisEngine:
         except Exception:
             logger.exception(
                 "gemini_turn_order_recovery_failed session_id=%s",
-                session_id,
+                sanitize_log(session_id),
             )
             raise
-        logger.info("gemini_turn_order_recovery_succeeded session_id=%s", session_id)
+        logger.info(
+            "gemini_turn_order_recovery_succeeded session_id=%s",
+            sanitize_log(session_id),
+        )
         return result
 
     def _analyze_once(self, prompt: str, session_id: str) -> str:
@@ -768,7 +772,7 @@ class StrandsAnalysisEngine:
         logger.info(
             "strands_analyze_once_timing session_id=%s "
             "cache_ms=%.1f lock_ms=%.1f invoke_ms=%.1f total_ms=%.1f",
-            session_id,
+            sanitize_log(session_id),
             (t_cache - t0) * 1000,
             (t_lock - t_cache) * 1000,
             (t_invoke - t_lock) * 1000,
@@ -782,7 +786,7 @@ class StrandsAnalysisEngine:
         except Exception:  # noqa: BLE001
             logger.warning(
                 "Failed to read stored conversation manager state for session=%s",
-                session_id,
+                sanitize_log(session_id),
             )
             return None
 

--- a/agent/app/core/log_sanitize.py
+++ b/agent/app/core/log_sanitize.py
@@ -1,0 +1,31 @@
+"""Log-injection defence helper.
+
+User-controlled values (HTTP request fields, query parameters, headers, etc.)
+must never be inserted into log records verbatim. CR/LF/NUL bytes can forge
+new log lines, break structured-log parsers, or smuggle ANSI escapes into
+operator terminals (CWE-117 - Log Injection / Log Forging).
+
+Wrap any such value with :func:`sanitize_log` before passing it to a logger:
+
+    logger.info("provider=%s", sanitize_log(request.provider))
+"""
+
+from __future__ import annotations
+
+import re
+
+# Strip the three control characters that are typically abused for log forging:
+#   \r (CR)   - line terminator on Windows / classic Mac
+#   \n (LF)   - line terminator on Unix
+#   \x00 (NUL) - C-string terminator, can truncate downstream consumers
+_CONTROL = re.compile(r"[\r\n\x00]")
+
+
+def sanitize_log(value: object) -> str:
+    """Return a log-safe string by replacing CR/LF/NUL with a single space.
+
+    Non-string inputs are coerced via :func:`str` so the helper is safe to use
+    on ints, dicts, exceptions, or any other object that may flow into a log
+    statement.
+    """
+    return _CONTROL.sub(" ", str(value))

--- a/agent/tests/test_log_sanitize.py
+++ b/agent/tests/test_log_sanitize.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import pytest
+
+from app.core.log_sanitize import sanitize_log
+
+
+class TestSanitizeLog:
+    def test_empty_string(self) -> None:
+        assert sanitize_log("") == ""
+
+    def test_plain_string_is_unchanged(self) -> None:
+        assert sanitize_log("provider=gemini") == "provider=gemini"
+
+    def test_strips_lf(self) -> None:
+        forged = "gemini\nINFO: forged log entry"
+        result = sanitize_log(forged)
+        assert "\n" not in result
+        assert result == "gemini INFO: forged log entry"
+
+    def test_strips_cr(self) -> None:
+        forged = "gemini\rINFO: forged log entry"
+        result = sanitize_log(forged)
+        assert "\r" not in result
+        assert result == "gemini INFO: forged log entry"
+
+    def test_strips_nul(self) -> None:
+        forged = "gemini\x00truncated"
+        result = sanitize_log(forged)
+        assert "\x00" not in result
+        assert result == "gemini truncated"
+
+    def test_strips_mixed_control_chars(self) -> None:
+        forged = "a\r\nb\x00c\nd"
+        result = sanitize_log(forged)
+        assert "\r" not in result
+        assert "\n" not in result
+        assert "\x00" not in result
+        # Each control char becomes a single space, so 4 control chars -> 4 spaces
+        assert result == "a  b c d"
+
+    def test_preserves_other_whitespace(self) -> None:
+        # Tabs and ordinary spaces must not be stripped
+        assert sanitize_log("a\tb c") == "a\tb c"
+
+    def test_non_string_int(self) -> None:
+        assert sanitize_log(42) == "42"
+
+    def test_non_string_dict(self) -> None:
+        # dict.__str__ output should be coerced and contain no control bytes
+        result = sanitize_log({"key": "value"})
+        assert "\n" not in result
+        assert "\r" not in result
+        assert "\x00" not in result
+        assert "key" in result
+        assert "value" in result
+
+    def test_non_string_none(self) -> None:
+        assert sanitize_log(None) == "None"
+
+    def test_non_string_with_embedded_lf_via_str(self) -> None:
+        class Custom:
+            def __str__(self) -> str:
+                return "hello\nworld"
+
+        assert sanitize_log(Custom()) == "hello world"
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        ("\n", " "),
+        ("\r", " "),
+        ("\x00", " "),
+        ("\r\n", "  "),
+        ("\n\n\n", "   "),
+    ],
+)
+def test_sanitize_log_parametrized_control_only(value: str, expected: str) -> None:
+    assert sanitize_log(value) == expected


### PR DESCRIPTION
## Summary

Resolve the 2 open CodeQL \`py/log-injection\` (high-severity) alerts in the KubeRCA agent service, plus 10 proactive wraps along the same call chain.

## Findings

CodeQL flagged \`request.provider\` and \`request.model_id\` flowing into a \`logger.info\` call in \`agent/app/api/config.py\`. The values come from a FastAPI request body, so an attacker can embed \`\\n\` / \`\\r\` to forge log entries (CWE-117).

The same value chain reaches \`strands_agent.py\` (via \`session_id\` and \`model_config\`) and \`llm_providers/factory.py\` (via \`provider_str\`); preventatively wrapping those sites avoids reopening the alert when the call paths shift.

## Changes (3 commits)

### \`feat(log): add sanitize_log helper to strip control characters\`
- New \`agent/app/core/log_sanitize.py\` — \`sanitize_log(value)\` strips \`\\n\`, \`\\r\`, \`\\x00\` so a tainted string cannot inject log lines. Accepts non-string types via \`str(value)\` for defensive use.
- New \`agent/tests/test_log_sanitize.py\` — 16 cases (empty, plain, \\n, \\r, \\x00, mixed, parametrized control-only, int, dict, None, custom \`__str__\`).

### \`fix(api): sanitize user-controlled values in logger calls\`
- \`agent/app/api/config.py\` — wrap \`request.provider\` and \`request.model_id\` (the 2 flagged alerts).
- \`agent/app/clients/strands_agent.py\` — wrap \`session_id\` across 6 logger sites + \`model_config.model_id\` at startup log.
- \`agent/app/clients/llm_providers/factory.py\` — wrap \`provider_str\` across 3 logger sites.

Total: **12 sites wrapped** (2 directly flagged + 10 along the same taint chain).

## Verification

- [x] \`uv run ruff check app tests\` — clean
- [x] \`uv run --extra dev pytest\` — 181 passed (165 existing + 16 new) in 7.03s
- [x] No public API surface changes; the wraps are pure logging-only.

## Expected post-merge effect

Open CodeQL \`py/log-injection\` alerts on default branch should drop from 2 → 0.