### PR TITLE
fix(backend): close residual go/log-injection (CodeQL barrier model + coverage)

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,24 @@
+# CodeQL configuration for kube-rca/kuberca.
+#
+# This config layers our custom data-extension model packs on top of the
+# default CodeQL query suites. The packs declare project-specific sanitisers
+# that the upstream queries do not know about (e.g. internal/logutil.Sanitize),
+# which keeps go/log-injection alert noise low without disabling the rule.
+#
+# The init action picks this file up via `config-file:` in
+# .github/workflows/codeql.yml.
+
+name: kuberca-codeql-config
+
+# Run the default + security-extended suites. The workflow also passes
+# `queries: security-extended` for backwards-compat with older CodeQL CLI
+# versions; either path produces the same query set.
+queries:
+  - uses: security-extended
+
+# Inject project-local model packs. Each pack lives under .github/codeql/
+# and contributes one or more YAML data extensions (see
+# https://codeql.github.com/docs/codeql-language-guides/customizing-library-models-for-go/).
+packs:
+  go:
+    - ./.github/codeql/log-injection-sanitizers

--- a/.github/codeql/log-injection-sanitizers/models/logutil.model.yml
+++ b/.github/codeql/log-injection-sanitizers/models/logutil.model.yml
@@ -1,0 +1,24 @@
+# Data extension: declare in-tree log-injection sanitisers.
+#
+# `internal/logutil.Sanitize` strips CR / LF / NUL from user-controlled
+# strings before they reach `log.Printf` / `log.Println` / similar
+# line-oriented loggers. CodeQL's go/log-injection query (CWE-117) does
+# not recognise the helper out of the box, so without this barrier model
+# every wrapped call site shows up as an open alert despite being safe.
+#
+# Schema for `barrierModel` (9 columns):
+#   [package, type, subtypes, name, signature, ext, output, kind, provenance]
+#
+# References:
+#   - https://github.blog/changelog/2026-04-21-codeql-now-supports-sanitizers-and-validators-in-models-as-data/
+#   - https://codeql.github.com/docs/codeql-language-guides/customizing-library-models-for-go/
+
+extensions:
+  - addsTo:
+      pack: codeql/go-all
+      extensible: barrierModel
+    data:
+      # logutil.Sanitize: package-level function, returns a sanitised string.
+      # The first argument's CR / LF / NUL are stripped before return, so the
+      # ReturnValue is treated as a barrier for log-injection sinks.
+      - ["github.com/kube-rca/backend/internal/logutil", "", false, "Sanitize", "", "", "ReturnValue", "log-injection", "manual"]

--- a/.github/codeql/log-injection-sanitizers/qlpack.yml
+++ b/.github/codeql/log-injection-sanitizers/qlpack.yml
@@ -1,0 +1,18 @@
+# CodeQL model pack: project-local sanitiser barriers.
+#
+# Declares barriers for queries shipped with `codeql/go-all` so the bundled
+# go/log-injection (CWE-117) data-flow analysis recognises in-tree helpers
+# such as `internal/logutil.Sanitize` as cleansing user-controlled values
+# before they reach `log.Printf` and friends.
+#
+# This pack is referenced from `.github/codeql/codeql-config.yml`.
+# See: https://codeql.github.com/docs/codeql-language-guides/customizing-library-models-for-go/
+name: kube-rca/log-injection-sanitizers
+version: 0.0.1
+library: true
+
+extensionTargets:
+  codeql/go-all: '*'
+
+dataExtensions:
+  - models/**/*.yml

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -54,6 +54,10 @@ jobs:
           build-mode: ${{ matrix.build-mode }}
           # Default + security-extended pack for higher recall on the security tier.
           queries: security-extended
+          # Layer in project-local data-extension packs (e.g. logutil.Sanitize
+          # as a go/log-injection barrier). Harmless on non-Go matrix entries —
+          # the Go-only pack simply doesn't apply when the target language differs.
+          config-file: ./.github/codeql/codeql-config.yml
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@b2f9ef845756500b97acbdaf5c1dd4e9c1d15734 # v3.35.2

--- a/backend/internal/client/webhook_routing_notifier.go
+++ b/backend/internal/client/webhook_routing_notifier.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/kube-rca/backend/internal/config"
+	"github.com/kube-rca/backend/internal/logutil"
 	"github.com/kube-rca/backend/internal/model"
 )
 
@@ -617,14 +618,14 @@ func (n *webhookRoutingNotifier) logThreadDeliverySkip(event NotifierEvent, deli
 	log.Printf(
 		"Skipping thread delivery (event_type=%s, alert_id=%s, fingerprint=%s, incident_id=%s, thread_ref=%s, webhook_config_id=%s, channel_id=%s, lookup_source=%s, skip_reason=%s)",
 		event.EventType(),
-		delivery.AlertID,
-		delivery.Fingerprint,
-		nullStringValue(delivery.IncidentID),
-		delivery.ThreadTS,
+		logutil.Sanitize(delivery.AlertID),
+		logutil.Sanitize(delivery.Fingerprint),
+		logutil.Sanitize(nullStringValue(delivery.IncidentID)),
+		logutil.Sanitize(delivery.ThreadTS),
 		webhookConfigID,
-		delivery.ChannelID,
-		lookupSource,
-		reason,
+		logutil.Sanitize(delivery.ChannelID),
+		logutil.Sanitize(lookupSource),
+		logutil.Sanitize(reason),
 	)
 }
 

--- a/backend/internal/handler/alert.go
+++ b/backend/internal/handler/alert.go
@@ -10,6 +10,7 @@ package handler
 import (
 	"encoding/json"
 	"github.com/gin-gonic/gin"
+	"github.com/kube-rca/backend/internal/logutil"
 	"github.com/kube-rca/backend/internal/model"
 	"github.com/kube-rca/backend/internal/service"
 	"log"
@@ -50,14 +51,14 @@ func (h *AlertHandler) Webhook(c *gin.Context) {
 
 	// 2. Raw payload 로깅 (디버깅용)
 	rawPayload, _ := json.MarshalIndent(webhook, "", "  ")
-	log.Printf("Raw webhook payload:\n%s", string(rawPayload))
+	log.Printf("Raw webhook payload:\n%s", logutil.Sanitize(string(rawPayload)))
 
 	// 3. 웹훅 메타데이터 로깅
 	// status: firing(발생) 또는 resolved(해결)
 	// alertCount: 웹훅에 포함된 알림 개수
 	// receiver: Alertmanager에서 설정한 receiver 이름
 	log.Printf("Received alert webhook: status=%s, alertCount=%d, receiver=%s",
-		webhook.Status, len(webhook.Alerts), webhook.Receiver)
+		logutil.Sanitize(webhook.Status), len(webhook.Alerts), logutil.Sanitize(webhook.Receiver))
 
 	// 4. 서비스 레이어에서 Slack 전송 처리
 	// 비즈니스 로직(필터링)은 service 레이어에 위임

--- a/backend/internal/logutil/sanitize.go
+++ b/backend/internal/logutil/sanitize.go
@@ -15,6 +15,25 @@ package logutil
 
 import "strings"
 
+// logInjectionReplacer strips the control characters CodeQL's go/log-injection
+// query (and CWE-117 in general) cares about: CR, LF, and NUL. CR and LF are
+// replaced with a single space so the surrounding log message remains visually
+// delimited; NUL is removed entirely because it has no useful display form.
+//
+// We intentionally use strings.NewReplacer here (instead of a hand-rolled scan
+// or repeated strings.ReplaceAll calls) because CodeQL's Go data-flow library
+// recognizes Replacer.Replace and Replacer.WriteString as built-in log-injection
+// barriers when all CR / LF code points are covered, so call sites wrapped with
+// Sanitize get treated as sanitised by the bundled go/log-injection query
+// without needing a custom model-as-data extension. See:
+//   - https://codeql.github.com/codeql-query-help/go/go-log-injection/
+//   - github/codeql-go#731 (string replacement sanitizers for log-injection)
+var logInjectionReplacer = strings.NewReplacer(
+	"\n", " ",
+	"\r", " ",
+	"\x00", "",
+)
+
 // Sanitize returns s with line-terminating and NUL control characters
 // stripped (CR, LF) or removed (NUL) so it cannot forge new log entries
 // when written through log.Printf or similar line-oriented loggers.
@@ -29,8 +48,5 @@ func Sanitize(s string) string {
 	if !strings.ContainsAny(s, "\n\r\x00") {
 		return s
 	}
-	s = strings.ReplaceAll(s, "\n", " ")
-	s = strings.ReplaceAll(s, "\r", " ")
-	s = strings.ReplaceAll(s, "\x00", "")
-	return s
+	return logInjectionReplacer.Replace(s)
 }


### PR DESCRIPTION
## Summary

Close every remaining \`go/log-injection\` CodeQL alert on \`kube-rca/kuberca\`.

PR #33 wrapped the originally-flagged 50 sites with \`logutil.Sanitize\`, but CodeQL on the next default-branch scan reopened ~59 of those alerts because **the engine did not recognise our custom \`Sanitize\` as a barrier**, plus 5 sites in \`handler/\` and \`client/\` were never in the original 50.

This PR addresses both gaps with three layered fixes — defence in depth so the closure degrades gracefully if any single mechanism is unavailable on the runner.

## Changes (3 commits)

### A. \`ci(codeql): declare logutil.Sanitize as a log-injection barrier\`
Add a CodeQL custom data-extension model so the engine treats \`logutil.Sanitize\` as a barrier for the \`log-injection\` flow query.

- \`.github/codeql/codeql-config.yml\` — top-level CodeQL config
- \`.github/codeql/log-injection-sanitizers/qlpack.yml\` — model pack manifest
- \`.github/codeql/log-injection-sanitizers/models/logutil.model.yml\` — \`barrierModel\` row registering the helper
- \`.github/workflows/codeql.yml\` — passes \`config-file: ./.github/codeql/codeql-config.yml\` to the init step

The row used is:
\`\`\`
["github.com/kube-rca/backend/internal/logutil", "", false, "Sanitize", "", "", "ReturnValue", "log-injection", "manual"]
\`\`\`
\`kind: "log-injection"\` matches the sink kind used in \`codeql/go-all\`'s shipped \`*.model.yml\` files (e.g. \`github.com.sirupsen.logrus.model.yml\`). Barrier-model support landed in CodeQL CLI 2.25.2 (April 2026), before the v3.35.2 action pinned in this workflow.

### B. \`refactor(logutil): rewrite Sanitize using strings.NewReplacer\`
Backstop in case the data-extension is not picked up: switch the helper internals to \`strings.NewReplacer(...).Replace(s)\`, a stdlib pattern CodeQL recognises by default.

- \`backend/internal/logutil/sanitize.go\` — same API, new internals
- Existing tests still pass (12 cases incl. idempotency)

### C. \`fix(backend): sanitize remaining log-injection sites in handler and client\`
Cover the 5 alerts the original PR did not touch.

- \`backend/internal/handler/alert.go\` — 3 sites
- \`backend/internal/client/webhook_routing_notifier.go\` — 2 sites in \`logThreadDeliverySkip\` plus surrounding fields preventatively

## Verification

- [x] \`gofmt -l .\` clean
- [x] \`go vet ./...\` clean
- [x] \`go test ./...\` green
- [x] \`golangci-lint run --timeout=5m -c .golangci.yml\` — 0 issues
- [x] All CodeQL YAML files parse via \`yq -e .\`

## Expected post-merge effect

Open CodeQL \`go/log-injection\` alerts on the default branch should drop from 59 → 0 once main runs CodeQL with the new config.

## References

- [CodeQL — sanitizers and validators in models-as-data](https://github.blog/changelog/2026-04-21-codeql-now-supports-sanitizers-and-validators-in-models-as-data/)
- [Customizing library models for Go](https://codeql.github.com/docs/codeql-language-guides/customizing-library-models-for-go/)
- [go/log-injection query help](https://codeql.github.com/codeql-query-help/go/go-log-injection/)
- [logrus.model.yml — \`kind: "log-injection"\`](https://github.com/github/codeql/blob/main/go/ql/lib/ext/github.com.sirupsen.logrus.model.yml)