### PR TITLE
fix(logutil): drop early returns so Sanitize is recognized as a barrier

### DIFF
--- a/backend/internal/logutil/sanitize.go
+++ b/backend/internal/logutil/sanitize.go
@@ -41,12 +41,16 @@ var logInjectionReplacer = strings.NewReplacer(
 // CR and LF are replaced with a single space rather than removed so that
 // the surrounding log message remains visually delimited; NUL is removed
 // entirely because it has no useful display form.
+//
+// The implementation always invokes logInjectionReplacer.Replace, even
+// when the input contains no control characters. The replacer's fast
+// path is already a no-op for clean strings, and skipping it with an
+// `if !ContainsAny … return s` early-return creates a dataflow path
+// where the caller-tainted value flows back to the return value
+// unchanged. CodeQL's go/log-injection analysis is path-insensitive at
+// the function summary level — any return-of-input path makes the
+// entire function appear to propagate taint, which prevents the rule
+// from recognising Sanitize as a barrier.
 func Sanitize(s string) string {
-	if s == "" {
-		return s
-	}
-	if !strings.ContainsAny(s, "\n\r\x00") {
-		return s
-	}
 	return logInjectionReplacer.Replace(s)
 }


### PR DESCRIPTION
## Summary

Close the residual ~59 \`go/log-injection\` alerts that kept reopening despite #33 + #37.

## Root cause

\`logutil.Sanitize\` had two early-return optimisations:

\`\`\`go
if s == "" { return s }
if !strings.ContainsAny(s, "\\n\\r\\x00") { return s }
return logInjectionReplacer.Replace(s)
\`\`\`

CodeQL's data-flow analysis is path-insensitive at the function summary level: any return-of-input path makes the entire function appear to propagate taint. The two \`return s\` paths above made Sanitize look like a pass-through to CodeQL, so all 50+ already-wrapped sites kept reopening as alerts on every default-branch scan, even after PR #37 added the explicit barrier model.

## Fix

Always invoke the replacer:

\`\`\`go
func Sanitize(s string) string {
    return logInjectionReplacer.Replace(s)
}
\`\`\`

\`strings.NewReplacer.Replace\` already short-circuits on clean strings (no allocation), so dropping the guard is performance-neutral. The replacer pattern is what CodeQL's bundled go/log-injection query recognises as a sanitiser.

## Verification

- [x] \`go fmt ./...\` clean
- [x] \`go test ./internal/logutil/... -race -count=1\` green (12 cases)

## Expected post-merge effect

Open CodeQL \`go/log-injection\` alerts on the default branch should drop from 59 → 0 once the next CodeQL run lands.