### PR TITLE
fix(ci): allow golang.org/x/arch in dependency-review

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -38,14 +38,15 @@ jobs:
           # action cannot match it against allow-licenses even though the base
           # BSD-3-Clause is permissive. Allow-list these by package URL.
           allow-dependencies-licenses: >-
-            pkg:golang/golang.org/x/time,
+            pkg:golang/golang.org/x/arch,
             pkg:golang/golang.org/x/crypto,
-            pkg:golang/golang.org/x/net,
-            pkg:golang/golang.org/x/sys,
-            pkg:golang/golang.org/x/text,
-            pkg:golang/golang.org/x/sync,
-            pkg:golang/golang.org/x/term,
             pkg:golang/golang.org/x/exp,
             pkg:golang/golang.org/x/mod,
+            pkg:golang/golang.org/x/net,
+            pkg:golang/golang.org/x/sync,
+            pkg:golang/golang.org/x/sys,
+            pkg:golang/golang.org/x/term,
+            pkg:golang/golang.org/x/text,
+            pkg:golang/golang.org/x/time,
             pkg:golang/golang.org/x/tools
           comment-summary-in-pr: on-failure


### PR DESCRIPTION
## Summary
- Adds `pkg:golang/golang.org/x/arch` to `allow-dependencies-licenses` in `.github/workflows/dependency-review.yml`
- Sorts the list alphabetically

## Why
PR #17 (backend Go group bump) transitively pulls in `golang.org/x/arch` via `gin-gonic/gin v1.12.0`. The dependency-review action rejects it because the package uses the compound license `BSD-3-Clause AND LicenseRef-scancode-google-patent-license-golang` — same pattern as the other `x/*` modules already in the allow list.

## Unblocks
- #17 (Go minor-and-patch group)

## Test plan
- [x] Diff inspected — only adds `x/arch` and re-sorts existing entries
- [ ] PR 17 `Review dependencies` job passes after this is merged