### PR TITLE
test(backend): add fuzz test for parseAnalyticsWindow

### DIFF
--- a/backend/internal/service/analytics_fuzz_test.go
+++ b/backend/internal/service/analytics_fuzz_test.go
@@ -1,0 +1,50 @@
+package service
+
+import (
+	"testing"
+	"time"
+)
+
+func FuzzParseAnalyticsWindow(f *testing.F) {
+	seeds := []string{
+		"",
+		"1h",
+		"24h",
+		"1d",
+		"30d",
+		"365d",
+		"0d",
+		"-1d",
+		"366d",
+		"abc",
+		"1.5d",
+		"1 d",
+		"  7d  ",
+		"1H",
+		"1y",
+		"99999999999999d",
+	}
+	for _, s := range seeds {
+		f.Add(s)
+	}
+
+	f.Fuzz(func(t *testing.T, raw string) {
+		duration, normalized, err := parseAnalyticsWindow(raw)
+		if err != nil {
+			if duration != 0 || normalized != "" {
+				t.Fatalf("error path returned non-zero values: duration=%v normalized=%q err=%v", duration, normalized, err)
+			}
+			return
+		}
+
+		if duration <= 0 {
+			t.Fatalf("non-error path returned non-positive duration %v for input %q", duration, raw)
+		}
+		if duration > 365*24*time.Hour {
+			t.Fatalf("non-error path exceeded 365d cap: duration=%v for input %q", duration, raw)
+		}
+		if normalized == "" {
+			t.Fatalf("non-error path returned empty normalized window for input %q", raw)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Resolves the OSSF Scorecard **FuzzingID** alert (current score: 0) by introducing a native Go fuzz test for the `parseAnalyticsWindow` parser in `backend/internal/service/analytics.go`.

This is a small, isolated, untrusted-string entry point — an ideal first fuzz target. The test asserts the parser's contract:

- on error → both return values are zero, no allocation leakage
- on success → duration is positive, capped at 365d, normalized window is non-empty

## Why this target

`parseAnalyticsWindow` accepts user-controlled `?window=` query strings on `GET /api/v1/analytics/dashboard`. Adding fuzz coverage prevents future regressions where a malformed window value could yield a non-error path with an invalid duration.

## Verification

```
$ go test ./internal/service/ -run '^$' -fuzz=FuzzParseAnalyticsWindow -fuzztime=5s
fuzz: elapsed: 6s, execs: 124875, new interesting: 81
PASS
ok  github.com/kube-rca/backend/internal/service  6.336s
```

- 124,875 execs in ~6 s, no crashes
- All existing backend tests still pass (`go test ./...`)
- `gofmt` / `go vet` clean

## Scorecard impact

| Alert | Before | After |
|-------|--------|-------|
| FuzzingID | score 0 (no fuzzer) | score >0 (native Go fuzz integrated) |

## Remaining Scorecard alerts (out of scope for this PR)

- `BranchProtectionID` — needs GitHub branch protection settings (admin action)
- `CodeReviewID` — historical %; improves naturally once branch protection requires reviews
- `CIIBestPracticesID` — needs external application at https://www.bestpractices.dev/
- `MaintainedID` — auto-resolves once repo is older than 90 days

## Test plan

- [x] `go test ./...` passes
- [x] `go test -fuzz=FuzzParseAnalyticsWindow -fuzztime=5s` runs without crashes
- [x] `gofmt -l` clean
- [x] `go vet ./...` clean