### PR TITLE
feat(agent): expose session window size + align helm defaults to python config

### DIFF
--- a/agent/app/clients/strands_agent.py
+++ b/agent/app/clients/strands_agent.py
@@ -680,6 +680,9 @@ class StrandsAnalysisEngine:
         self._retry_max_wait = settings.llm_retry_max_wait
         self._retry_total_timeout = settings.llm_retry_total_timeout
 
+        # Conversation manager sliding window (configurable via AGENT_SESSION_WINDOW_SIZE)
+        self._session_window_size = max(1, settings.agent_session_window_size)
+
         # Log provider info
         if model_config:
             logger.info(
@@ -873,7 +876,9 @@ class StrandsAnalysisEngine:
             session_id=session_id,
             session_repository=self._session_repo,
         )
-        conversation_manager = SafeSlidingWindowConversationManager(window_size=40)
+        conversation_manager = SafeSlidingWindowConversationManager(
+            window_size=self._session_window_size,
+        )
         return Agent(
             model=model,
             tools=self._tools,

--- a/agent/app/core/config.py
+++ b/agent/app/core/config.py
@@ -128,6 +128,8 @@ class Settings:
     llm_retry_total_timeout: float = 180.0
     # Concurrency
     max_concurrent_analyses: int = 5
+    # Conversation manager sliding window
+    agent_session_window_size: int = 40
 
     @property
     def session_store_dsn(self) -> str:
@@ -200,4 +202,6 @@ def load_settings() -> Settings:
         llm_retry_total_timeout=_get_float_env("LLM_RETRY_TOTAL_TIMEOUT", 180.0),
         # Concurrency
         max_concurrent_analyses=_get_int_env("MAX_CONCURRENT_ANALYSES", 5),
+        # Conversation manager sliding window
+        agent_session_window_size=max(1, _get_int_env("AGENT_SESSION_WINDOW_SIZE", 40)),
     )

--- a/agent/uv.lock
+++ b/agent/uv.lock
@@ -884,7 +884,7 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.4.0,<3.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3,<10.0.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.24" },
-    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=6.0.0,<7.0.0" },
+    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=6.0.0,<8.0.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.13.0,<0.16.0" },
     { name = "strands-agents", extras = ["gemini", "openai", "anthropic"], specifier = ">=1.30.0,<2.0.0" },
     { name = "tenacity", specifier = ">=9.0.0,<10.0.0" },

--- a/charts/kube-rca/templates/agent/deployment.yaml
+++ b/charts/kube-rca/templates/agent/deployment.yaml
@@ -137,11 +137,16 @@ spec:
               value: {{ $cacheTtl | quote }}
             {{- $retry := default (dict) .Values.agent.retry }}
             - name: LLM_RETRY_MAX_ATTEMPTS
-              value: {{ default 5 $retry.maxAttempts | quote }}
+              value: {{ default 10 $retry.maxAttempts | quote }}
             - name: LLM_RETRY_MIN_WAIT
               value: {{ default 1.0 $retry.minWait | quote }}
             - name: LLM_RETRY_MAX_WAIT
-              value: {{ default 60.0 $retry.maxWait | quote }}
+              value: {{ default 30.0 $retry.maxWait | quote }}
+            - name: LLM_RETRY_TOTAL_TIMEOUT
+              value: {{ default 180.0 $retry.totalTimeout | quote }}
+            {{- $session := default (dict) .Values.agent.session }}
+            - name: AGENT_SESSION_WINDOW_SIZE
+              value: {{ default 40 $session.windowSize | quote }}
             {{- $sessionDB := default (dict) .Values.agent.sessionDB }}
             {{- $sessionDBHost := default "" $sessionDB.host }}
             {{- if $sessionDBHost }}

--- a/charts/kube-rca/values.yaml
+++ b/charts/kube-rca/values.yaml
@@ -362,7 +362,7 @@ agent:
     tenantId: ""
   gemini:
     # -- Gemini model ID for Strands Agents.
-    modelId: "gemini-3.1-flash-lite-preview"
+    modelId: "gemini-3-flash-preview"
     # -- Gemini API key value. When set (and no existingSecret), chart creates the Secret.
     apiKey: ""
     secret:
@@ -419,11 +419,18 @@ agent:
     ttlSeconds: 0
   retry:
     # -- Max retry attempts for transient LLM API errors (5xx, 429).
-    maxAttempts: 5
+    maxAttempts: 10
     # -- Minimum exponential backoff wait time in seconds.
     minWait: 1.0
     # -- Maximum exponential backoff wait time in seconds.
-    maxWait: 60.0
+    maxWait: 30.0
+    # -- Total timeout in seconds before giving up retries (LLM_RETRY_TOTAL_TIMEOUT).
+    totalTimeout: 180.0
+  session:
+    # -- Sliding window size for the conversation manager (AGENT_SESSION_WINDOW_SIZE).
+    #    Controls how many recent messages are kept in the LLM context per session.
+    #    Trade-off: larger window improves continuity but increases prompt token cost.
+    windowSize: 40
   # -- Node labels for agent pods assignment.
   nodeSelector: {}
   # -- Tolerations for agent pods assignment.


### PR DESCRIPTION
## Summary
- Surfaces the conversation manager sliding window as `agent.session.windowSize` (default 40) so operators can tune it without rebuilding the agent image.
- Aligns Helm `agent.retry.*` defaults to `agent/app/core/config.py` (maxAttempts 5->10, maxWait 60.0->30.0) and exposes `LLM_RETRY_TOTAL_TIMEOUT` (180.0) as a Helm key.
- Pins `agent.gemini.modelId` to `gemini-3-flash-preview` (match `agent/app/clients/llm_providers/base.py:71`).

## Test plan
- [x] `cd agent && uv run ruff check app/core/config.py app/clients/strands_agent.py` — passes
- [x] `cd .. && helm dep update charts/kube-rca && helm lint charts/kube-rca` — 1 chart linted, 0 failed
- [x] `python yaml.safe_load values.yaml` — session.windowSize=40 parsed
- [ ] Smoke deploy with `agent.session.windowSize=20` overlay → confirm `AGENT_SESSION_WINDOW_SIZE=20` env on agent pod
- [ ] Smoke deploy with `agent.retry.maxAttempts=3` overlay → confirm `LLM_RETRY_MAX_ATTEMPTS=3` env on agent pod