### PR TITLE
chore(charts): tune agent defaults - sonnet 4.6 + totalTimeout 300s

### DIFF
--- a/charts/kube-rca/values.yaml
+++ b/charts/kube-rca/values.yaml
@@ -386,7 +386,7 @@ agent:
       key: "openai-api-key"
   anthropic:
     # -- Anthropic model ID for Strands Agents.
-    modelId: "claude-haiku-4-5"
+    modelId: "claude-sonnet-4-6"
     # -- Anthropic maximum output tokens.
     maxTokens: 8192
     # -- Anthropic API key value. When set (and no existingSecret), chart creates the Secret.

--- a/charts/kube-rca/values.yaml
+++ b/charts/kube-rca/values.yaml
@@ -425,7 +425,7 @@ agent:
     # -- Maximum exponential backoff wait time in seconds.
     maxWait: 30.0
     # -- Total timeout in seconds before giving up retries (LLM_RETRY_TOTAL_TIMEOUT).
-    totalTimeout: 180.0
+    totalTimeout: 300.0
   session:
     # -- Sliding window size for the conversation manager (AGENT_SESSION_WINDOW_SIZE).
     #    Controls how many recent messages are kept in the LLM context per session.


### PR DESCRIPTION
## Summary

- agent.anthropic.modelId: claude-haiku-4-5 -> claude-sonnet-4-6 (mid-tier balanced model, intentionally not Opus)
- agent.retry.totalTimeout: 180.0 -> 300.0 (headroom for high-reasoning models on multi-tool runs)

Both defaults derived from KubeRCA OSSNA26 presentation prep
(LF OSS Summit NA 2026, Minneapolis, 2026-05-18).

## Context

- S31 (Model Choice - Speed x Quality): operative defaults are now Gemini Flash preview / GPT-5-Mini / Claude Sonnet 4.6
- S35 (LLM Call Safety): totalTimeout 300s + windowSize 40 both Helm-tunable knobs

## Test plan

- [x] presentation make verify (49 slides / 7 diagrams / lint / doc-freshness)
- [x] presentation make drift-check (6 surfaces clean)
- [ ] CI: helm lint / chart values schema