### PR TITLE
fix(agent): clean up bandit findings + drop continue-on-error gate

### DIFF
--- a/.github/workflows/ci-agent.yaml
+++ b/.github/workflows/ci-agent.yaml
@@ -38,12 +38,9 @@ jobs:
         continue-on-error: true
       - name: Security scan (bandit)
         working-directory: agent
-        # Soft-fail on PRs to avoid blocking on pre-existing findings while the
-        # agent codebase is annotated. The CodeQL py-extended pack is the
-        # blocking SAST gate; bandit is informational here.
-        # TODO(governance): triage bandit findings, add `# nosec BXXX` with
-        # justification at known-safe sites, then drop continue-on-error.
-        continue-on-error: true
+        # Blocking gate: high-severity + high-confidence findings only (-ll -ii).
+        # Pre-existing low-severity findings (B105 placeholder, B112 fault-tolerant
+        # loop) are annotated with `# nosec BXXX` + justification at the call site.
         run: |
           uvx --from bandit bandit -r app -ll -ii
       - name: Vulnerability scan (pip-audit)

--- a/agent/app/clients/k8s.py
+++ b/agent/app/clients/k8s.py
@@ -806,7 +806,7 @@ class KubernetesClient:
         for item in data.get("items", []):
             try:
                 summaries.append(self._to_event_summary_v1_raw(item))
-            except Exception:  # noqa: BLE001
+            except Exception:  # noqa: BLE001  # nosec B112 - drop malformed items; outer except already logs API errors
                 continue
         return summaries, None
 

--- a/agent/app/core/masking.py
+++ b/agent/app/core/masking.py
@@ -12,42 +12,48 @@ MASK_TOKEN = "[MASKED]"  # nosec B105 - placeholder token for masked output, not
 # ---------------------------------------------------------------------------
 # Key denylist / allowlist for dict-key-based masking
 # ---------------------------------------------------------------------------
-_KEY_DENYLIST = frozenset([
-    "password",
-    "token",
-    "secret",
-    "key",
-    "credential",
-    "authorization",
-    "api_key",
-    "apikey",
-    "private_key",
-    "access_key",
-    "client_secret",
-])
+_KEY_DENYLIST = frozenset(
+    [
+        "password",
+        "token",
+        "secret",
+        "key",
+        "credential",
+        "authorization",
+        "api_key",
+        "apikey",
+        "private_key",
+        "access_key",
+        "client_secret",
+    ]
+)
 
-_KEY_ALLOWLIST = frozenset([
-    "secret_name",
-    "token_budget",
-    "service_account_token",
-    "secret_ref",
-    "secret_key_ref",
-    "key_ref",
-])
+_KEY_ALLOWLIST = frozenset(
+    [
+        "secret_name",
+        "token_budget",
+        "service_account_token",
+        "secret_ref",
+        "secret_key_ref",
+        "key_ref",
+    ]
+)
 
 # ---------------------------------------------------------------------------
 # Value heuristic allowlist — fields whose values look like base64/tokens
 # but are not sensitive (e.g. K8s metadata fields)
 # ---------------------------------------------------------------------------
-_VALUE_HEURISTIC_SKIP_KEYS = frozenset([
-    "image",
-    "imageid",
-    "containerid",
-    "resourceversion",
-    "uid",
-    "selflink",
-    "generation",
-])
+_VALUE_HEURISTIC_SKIP_KEYS = frozenset(
+    [
+        "image",
+        "imageid",
+        "containerid",
+        "resourceversion",
+        "uid",
+        "selflink",
+        "generation",
+    ]
+)
 
 # ---------------------------------------------------------------------------
 # K8s annotation prefixes that are safe to keep unmasked
@@ -182,9 +188,7 @@ class BuiltinRedactor:
 
         # Apply regex-based patterns
         for pattern in _VALUE_PATTERNS:
-            result = pattern.sub(
-                lambda m: _mask_replacement(self.hash_mode, m.group(0)), result
-            )
+            result = pattern.sub(lambda m: _mask_replacement(self.hash_mode, m.group(0)), result)
 
         # Long base64 — only mask if it's valid base64
         def _base64_replacer(m: re.Match[str]) -> str:

--- a/agent/app/core/masking.py
+++ b/agent/app/core/masking.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass, field
 from re import Pattern
 from typing import Any, Protocol, runtime_checkable
 
-MASK_TOKEN = "[MASKED]"
+MASK_TOKEN = "[MASKED]"  # nosec B105 - placeholder token for masked output, not a credential
 
 # ---------------------------------------------------------------------------
 # Key denylist / allowlist for dict-key-based masking


### PR DESCRIPTION
## Summary

KAN-44 (#44) Phase 3 — Bandit cleanup 선행 PR. W3 정착 점검과 독립적으로 진행.

- **B105** (`agent/app/core/masking.py:10`) — `MASK_TOKEN = "[MASKED]"` 는 마스킹 출력용 placeholder 상수. credential 아님 → `# nosec B105` 추가.
- **B112** (`agent/app/clients/k8s.py:809`) — K8s 이벤트 변환 루프의 try/except/continue. malformed item만 의도적으로 drop, outer except가 line 803에서 API 에러는 별도 로깅 → `# nosec B112` 추가.
- **CI gate**: `.github/workflows/ci-agent.yaml` 의 bandit step에서 `continue-on-error: true` 제거. 이제 `bandit -ll -ii` 가 blocking gate로 동작하고, TODO(governance) 주석도 제거.

## Commit 분리

| Commit | 내용 |
|--------|------|
| `37634fa` | fix(agent): bandit cleanup + CI gate (3 files, 5+/8-) |
| `43ec940` | chore(agent): apply ruff format to `app/core/masking.py` (이 PR scope에서 발견된 main의 ruff format drift 정리, semantic 변경 없음) |

## Test plan

- [x] `cd agent && uvx --from bandit bandit -r app -ll -ii` → `No issues identified` (7 nosec 인식: 5 pre-existing + 2 신규)
- [x] `cd agent && uv run ruff check app` → `All checks passed!`
- [x] `cd agent && uv run ruff format --check app/core/masking.py` → clean
- [x] `cd agent && uv run pytest tests/test_masking.py tests/test_k8s_manifest_tools.py` → 28 passed
- [ ] CI ci-agent workflow 그린 확인 (PR 머지 전)

## Notes

Bandit이 `# nosec B105 - <reason>` 형식의 자유 텍스트 단어를 test name 후보로 오인해 cosmetic WARNING 3줄을 출력합니다 (예: `Test in comment: placeholder is not a test name or id, ignoring`). 게이트 동작 및 finding 카운트에는 영향이 없습니다. 사유를 별도 라인 코멘트로 분리하면 warning은 사라지지만, repo의 ruff format hook이 별도 라인 코멘트를 inline 으로 합쳐버려 선택적으로 적용 불가했습니다.

## Refs

- Issue: #44
- W3 PR: #43 (머지 SHA `80ae75e`)
- Phase 3 (Bandit cleanup) of KAN-44 — Phase 1 (coverage 측정) / Phase 2 (A/B/C 결정) 은 2026-05-11 이후 별도 PR