### PR TITLE
feat(agent): gate istio crd tools via agent.istio.enabled helm flag

### DIFF
--- a/agent/app/clients/strands_agent.py
+++ b/agent/app/clients/strands_agent.py
@@ -666,7 +666,12 @@ class StrandsAnalysisEngine:
         self._model_config = model_config
         self._masker = masker or RegexMasker()
         self._tools = _build_tools(
-            k8s_client, prometheus_client, tempo_client, loki_client, self._masker
+            k8s_client,
+            prometheus_client,
+            tempo_client,
+            loki_client,
+            self._masker,
+            istio_enabled=settings.agent_istio_enabled,
         )
         self._cache_lock = Lock()
         self._agent_cache: OrderedDict[str, _AgentCacheEntry] = OrderedDict()
@@ -911,6 +916,8 @@ def _build_tools(
     tempo_client: TempoClient | None,
     loki_client: LokiClient | None,
     masker: Masker,
+    *,
+    istio_enabled: bool = False,
 ) -> list[object]:
     def _mask(data: Any) -> Any:
         return masker.mask_object(data)
@@ -1281,10 +1288,15 @@ def _build_tools(
         get_node_metrics,
         get_manifest,
         list_manifests,
-        list_virtual_services,
-        list_destination_rules,
-        list_service_entries,
     ]
+    if istio_enabled:
+        tools.extend(
+            [
+                list_virtual_services,
+                list_destination_rules,
+                list_service_entries,
+            ]
+        )
     if prometheus_client is not None:
         tools.extend(
             [

--- a/agent/app/clients/strands_agent.py
+++ b/agent/app/clients/strands_agent.py
@@ -917,6 +917,9 @@ def _build_tools(
     loki_client: LokiClient | None,
     masker: Masker,
     *,
+    # Istio CRDs piggyback on k8s_client (no separate endpoint), so we gate
+    # via a Helm-driven boolean instead of a client-null check like the
+    # other enrichers (Prometheus / Tempo / Loki).
     istio_enabled: bool = False,
 ) -> list[object]:
     def _mask(data: Any) -> Any:

--- a/agent/app/core/config.py
+++ b/agent/app/core/config.py
@@ -130,6 +130,10 @@ class Settings:
     max_concurrent_analyses: int = 5
     # Conversation manager sliding window
     agent_session_window_size: int = 40
+    # Istio mesh CRD tools (Helm-controlled). Default off; enable in clusters
+    # where Istio is installed so the agent can list VirtualService /
+    # DestinationRule / ServiceEntry resources.
+    agent_istio_enabled: bool = False
 
     @property
     def session_store_dsn(self) -> str:
@@ -204,4 +208,6 @@ def load_settings() -> Settings:
         max_concurrent_analyses=_get_int_env("MAX_CONCURRENT_ANALYSES", 5),
         # Conversation manager sliding window
         agent_session_window_size=max(1, _get_int_env("AGENT_SESSION_WINDOW_SIZE", 40)),
+        # Istio mesh CRD tools (Helm-controlled)
+        agent_istio_enabled=os.getenv("AGENT_ISTIO_ENABLED", "false").lower() == "true",
     )

--- a/agent/tests/test_strands_tools.py
+++ b/agent/tests/test_strands_tools.py
@@ -5,7 +5,11 @@ from app.core.masking import RegexMasker
 
 
 def _tool_names(
-    *, prometheus: object | None, tempo: object | None, loki: object | None
+    *,
+    prometheus: object | None,
+    tempo: object | None,
+    loki: object | None,
+    istio_enabled: bool = False,
 ) -> set[str]:
     tools = _build_tools(
         k8s_client=object(),
@@ -13,12 +17,13 @@ def _tool_names(
         tempo_client=tempo,
         loki_client=loki,
         masker=RegexMasker(),
+        istio_enabled=istio_enabled,
     )
     return {tool.tool_name for tool in tools}
 
 
 def test_build_tools_registers_portable_wrapper_tools() -> None:
-    names = _tool_names(prometheus=object(), tempo=object(), loki=object())
+    names = _tool_names(prometheus=object(), tempo=object(), loki=object(), istio_enabled=True)
 
     assert "get_service" in names
     assert "get_endpoints" in names
@@ -31,7 +36,7 @@ def test_build_tools_registers_portable_wrapper_tools() -> None:
 
 
 def test_build_tools_omits_optional_observability_tools_when_clients_are_missing() -> None:
-    names = _tool_names(prometheus=None, tempo=None, loki=None)
+    names = _tool_names(prometheus=None, tempo=None, loki=None, istio_enabled=True)
 
     assert "get_service" in names
     assert "get_endpoints" in names
@@ -39,3 +44,17 @@ def test_build_tools_omits_optional_observability_tools_when_clients_are_missing
     assert "query_prometheus" not in names
     assert "search_tempo_traces" not in names
     assert "query_loki" not in names
+
+
+def test_build_tools_omits_istio_tools_when_istio_disabled() -> None:
+    names = _tool_names(
+        prometheus=object(),
+        tempo=object(),
+        loki=object(),
+        istio_enabled=False,
+    )
+
+    assert "get_service" in names
+    assert "list_virtual_services" not in names
+    assert "list_destination_rules" not in names
+    assert "list_service_entries" not in names

--- a/charts/kube-rca/kube-rca-values.yaml
+++ b/charts/kube-rca/kube-rca-values.yaml
@@ -85,6 +85,8 @@ agent:
   loki:
     url: http://loki-gateway.monitoring.svc.cluster.local:80
     tenantId: "kube-rca"
+  istio:
+    enabled: true
   prompt:
     tokenBudget: 32000
     maxLogLines: 25

--- a/charts/kube-rca/templates/agent/deployment.yaml
+++ b/charts/kube-rca/templates/agent/deployment.yaml
@@ -147,6 +147,9 @@ spec:
             {{- $session := default (dict) .Values.agent.session }}
             - name: AGENT_SESSION_WINDOW_SIZE
               value: {{ default 40 $session.windowSize | quote }}
+            {{- $istio := default (dict) .Values.agent.istio }}
+            - name: AGENT_ISTIO_ENABLED
+              value: {{ default false $istio.enabled | quote }}
             {{- $sessionDB := default (dict) .Values.agent.sessionDB }}
             {{- $sessionDBHost := default "" $sessionDB.host }}
             {{- if $sessionDBHost }}

--- a/charts/kube-rca/values.yaml
+++ b/charts/kube-rca/values.yaml
@@ -360,6 +360,11 @@ agent:
     httpTimeoutSeconds: 10
     # -- Optional Loki tenant header value (LOKI_TENANT_ID / X-Scope-OrgID).
     tenantId: ""
+  istio:
+    # -- Enable Istio mesh CRD tools (VirtualService / DestinationRule / ServiceEntry).
+    # Set true only when Istio is installed in the cluster; otherwise the agent
+    # registers no Istio tools so the LLM never sees an unavailable capability.
+    enabled: false
   gemini:
     # -- Gemini model ID for Strands Agents.
     modelId: "gemini-3-flash-preview"


### PR DESCRIPTION
## Summary
- Helm-gate Istio CRD tools (`list_virtual_services` / `list_destination_rules` / `list_service_entries`) behind a new `agent.istio.enabled` flag (default **false**), matching the existing Prom/Tempo/Loki client-null gating pattern.
- `kube-rca-values.yaml` overrides to `true` for the KubeRCA cluster (Istio is installed there). Default-off chart install no longer registers Istio tools the LLM cannot exercise.
- Pure refactor on tool counts: K8s base goes 20 → 17 (Istio tools split out into a separate enricher), total stays 32.

## Changes
| Layer | File | Change |
|---|---|---|
| Chart | `charts/kube-rca/values.yaml` | New `agent.istio.enabled: false` block with rationale comment |
| Chart | `charts/kube-rca/kube-rca-values.yaml` | Override `agent.istio.enabled: true` |
| Chart | `charts/kube-rca/templates/agent/deployment.yaml` | Inject `AGENT_ISTIO_ENABLED` env (default false) |
| Agent | `agent/app/core/config.py` | Add `agent_istio_enabled: bool = False` to `Settings`, env loader reads `AGENT_ISTIO_ENABLED` |
| Agent | `agent/app/clients/strands_agent.py` | `_build_tools` accepts `istio_enabled` kwarg; Istio block hoisted out of K8s base into `if istio_enabled: tools.extend([...])` |
| Tests | `agent/tests/test_strands_tools.py` | Existing assertions now pass `istio_enabled=True`; new `test_build_tools_omits_istio_tools_when_istio_disabled` locks the default-off contract |

## Validation
- `make lint` (agent): `All checks passed!`
- `make test` (agent): **201 passed** (1 new test added for the disabled path)
- `helm dep build` + `helm lint charts/kube-rca`: 1 chart linted, 0 failed
- `helm template`:
  - default values → `AGENT_ISTIO_ENABLED: "false"`
  - with `kube-rca-values.yaml` → `AGENT_ISTIO_ENABLED: "true"`

## Backward compatibility
- Existing installs that rely on Istio CRD tools must explicitly set `agent.istio.enabled: true` in their values override. Documented via the comment in `values.yaml` and reflected in `kube-rca-values.yaml`.

## Test plan
- [x] Agent unit tests pass (201/201)
- [x] Helm lint clean after `dep build`
- [x] Env injection verified in both default and override scenarios
- [ ] Smoke test on dev cluster after image rebuild (next step)