### PR TITLE
fix(ci): correct helm/kind-action SHA in chaos-weekly workflow

### DIFF
--- a/.github/workflows/chaos-weekly.yaml
+++ b/.github/workflows/chaos-weekly.yaml
@@ -39,7 +39,7 @@ jobs:
           esac
 
       - name: Create kind cluster
-        uses: helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70863de9 # v1.12.0
+        uses: helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70863de3 # v1.12.0
         with:
           cluster_name: chaos-ci
           wait: 120s


### PR DESCRIPTION
## Summary

The `chaos-weekly.yaml` workflow has been failing every Monday since it was introduced — failing in 6 seconds with:

```
Unable to resolve action `helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70863de9`,
unable to find version `a1b0e391336a6ee6713a0583f8c6240d70863de9`
```

The pinned SHA is off by one character. The actual `v1.12.0` tag SHA is:

| Pinned (broken) | `a1b0e391336a6ee6713a0583f8c6240d70863de`**`9`** |
| Actual `v1.12.0` | `a1b0e391336a6ee6713a0583f8c6240d70863de`**`3`** |

Verified via:
```
gh api repos/helm/kind-action/git/refs/tags/v1.12.0 --jq '.object.sha'
# -> a1b0e391336a6ee6713a0583f8c6240d70863de3
```

## Test plan

- [ ] Workflow re-run on this PR resolves the action successfully
- [ ] Next scheduled `chaos-weekly` run completes (or fails for a non-action-resolution reason)

Recent failed runs:
- https://github.com/kube-rca/kuberca/actions/runs/25304251783
- https://github.com/kube-rca/kuberca/actions/runs/24979368743