### PR TITLE
feat(agent): expand client coverage with monkeypatch fakes + testcontainers (#76)

### DIFF
--- a/.github/workflows/ci-agent.yaml
+++ b/.github/workflows/ci-agent.yaml
@@ -51,13 +51,11 @@ jobs:
         # the dependency-review workflow is the blocking gate for CVE introduction.
       - name: Test (coverage)
         working-directory: agent
-        # --cov-fail-under=55: measured baseline after W3 additions is 57.79 %.
-        # The gap to 70 % is driven by strands_agent.py (LLM integration,
-        # 55 %), session_repository.py (Postgres, 23 %), and prometheus.py
-        # (live scrape, 20 %) — all require real infrastructure to cover fully.
-        # Threshold is set 3 pp below current to absorb minor measurement
-        # variance without blocking PRs on pre-existing infra-bound paths.
-        run: pytest --cov=app --cov-report=xml --cov-report=term --cov-fail-under=55
+        # --cov-fail-under=65: prometheus / session_repository / k8s now covered
+        # via fakes + testcontainers (pgvector/pgvector:pg16).
+        # Measured baseline after this change is ~68 %+, gate set 3 pp below
+        # to absorb minor variance without blocking PRs.
+        run: pytest --cov=app --cov-report=xml --cov-report=term --cov-fail-under=65
       - name: Upload coverage to Codecov
         if: always()
         uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0

--- a/agent/pyproject.toml
+++ b/agent/pyproject.toml
@@ -26,6 +26,7 @@ dev = [
   "pytest-cov>=6.0.0,<8.0.0",
   "httpx>=0.27",
   "ruff>=0.13.0,<0.16.0",
+  "testcontainers[postgres]>=4.0",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/agent/tests/conftest.py
+++ b/agent/tests/conftest.py
@@ -1,8 +1,29 @@
 from __future__ import annotations
 
+import os
 import sys
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
+
+# Auto-detect Docker socket for testcontainers when DOCKER_HOST is not set.
+# Rancher Desktop and OrbStack expose the socket at a non-standard path on macOS;
+# testcontainers' docker-py client falls back to /var/run/docker.sock by default.
+if not os.environ.get("DOCKER_HOST"):
+    _CANDIDATE_SOCKETS = [
+        Path.home() / ".rd" / "docker.sock",  # Rancher Desktop
+        Path.home() / ".orbstack" / "run" / "docker.sock",  # OrbStack
+        Path("/var/run/docker.sock"),  # Linux / Docker Desktop (standard)
+    ]
+    for _sock in _CANDIDATE_SOCKETS:
+        if _sock.exists():
+            os.environ["DOCKER_HOST"] = f"unix://{_sock}"
+            break
+
+# Disable testcontainers Ryuk reaper unconditionally.
+# Ryuk requires privileged mounts that are unavailable on Rancher Desktop (macOS)
+# and some CI runners. Container cleanup is handled by the Python context manager
+# in the fixture, so ryuk is not needed for correctness.
+os.environ["TESTCONTAINERS_RYUK_DISABLED"] = "true"

--- a/agent/tests/test_k8s_client.py
+++ b/agent/tests/test_k8s_client.py
@@ -82,11 +82,6 @@ def _make_event(
     )
 
 
-def _make_item_list(items: list[Any], list_class: Any) -> Any:
-    obj = list_class(items=items)
-    return obj
-
-
 def _client(
     core_api: Any = None,
     apps_api: Any = None,
@@ -323,8 +318,10 @@ def test_get_node_status_returns_dict() -> None:
     assert result is not None
     assert result["name"] == "node-1"
     assert result["unschedulable"] is False
-    assert len(result["conditions"]) == 1
-    assert result["conditions"][0]["type"] == "Ready"  # type: ignore[index]
+    conditions = result["conditions"]
+    assert isinstance(conditions, list)
+    assert len(conditions) == 1
+    assert conditions[0]["type"] == "Ready"  # type: ignore[index]
 
 
 def test_get_node_status_api_error_returns_none() -> None:

--- a/agent/tests/test_k8s_client.py
+++ b/agent/tests/test_k8s_client.py
@@ -1,0 +1,855 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+from kubernetes import client as k8s_client
+
+from app.clients.k8s import KubernetesClient
+
+# ---------------------------------------------------------------------------
+# Helpers — fake kubernetes API objects
+# ---------------------------------------------------------------------------
+
+
+def _make_pod(
+    name: str = "test-pod",
+    namespace: str = "bookinfo",
+    phase: str = "Running",
+    containers: list[str] | None = None,
+    owner_kind: str | None = None,
+    owner_name: str | None = None,
+) -> k8s_client.V1Pod:
+    containers = containers or ["app"]
+    container_objs = [k8s_client.V1Container(name=c) for c in containers]
+    owner_refs = []
+    if owner_kind and owner_name:
+        owner_refs.append(
+            k8s_client.V1OwnerReference(
+                api_version="apps/v1",
+                kind=owner_kind,
+                name=owner_name,
+                uid="uid-1",
+                controller=True,
+            )
+        )
+    return k8s_client.V1Pod(
+        metadata=k8s_client.V1ObjectMeta(
+            name=name,
+            namespace=namespace,
+            labels={"app": name},
+            owner_references=owner_refs,
+        ),
+        spec=k8s_client.V1PodSpec(
+            containers=container_objs,
+            node_name="node-1",
+        ),
+        status=k8s_client.V1PodStatus(
+            phase=phase,
+            container_statuses=[
+                k8s_client.V1ContainerStatus(
+                    name=c,
+                    ready=True,
+                    restart_count=0,
+                    image="nginx:latest",
+                    image_id="",
+                )
+                for c in containers
+            ],
+        ),
+    )
+
+
+def _make_event(
+    reason: str = "OOMKilling",
+    message: str = "OOM killed",
+    type: str = "Warning",
+    namespace: str = "bookinfo",
+    pod_name: str = "test-pod",
+) -> k8s_client.CoreV1Event:
+    return k8s_client.CoreV1Event(
+        metadata=k8s_client.V1ObjectMeta(name="event-1", namespace=namespace),
+        reason=reason,
+        message=message,
+        type=type,
+        count=1,
+        involved_object=k8s_client.V1ObjectReference(
+            kind="Pod",
+            name=pod_name,
+            namespace=namespace,
+        ),
+    )
+
+
+def _make_item_list(items: list[Any], list_class: Any) -> Any:
+    obj = list_class(items=items)
+    return obj
+
+
+def _client(
+    core_api: Any = None,
+    apps_api: Any = None,
+    batch_api: Any = None,
+    custom_api: Any = None,
+    events_api: Any = None,
+) -> KubernetesClient:
+    """Build a KubernetesClient with pre-wired fake APIs, bypassing _build_client."""
+    with patch.object(KubernetesClient, "_build_client", return_value=core_api or MagicMock()):
+        inst = KubernetesClient(timeout_seconds=10, event_limit=100, log_tail_lines=50)
+    inst._core_api = core_api
+    inst._apps_api = apps_api
+    inst._batch_api = batch_api
+    inst._custom_api = custom_api
+    inst._events_api = events_api
+    return inst
+
+
+# ---------------------------------------------------------------------------
+# collect_context — namespace / pod_name routing
+# ---------------------------------------------------------------------------
+
+
+def test_collect_context_missing_namespace_returns_warning() -> None:
+    c = _client()
+    ctx = c.collect_context(namespace=None, pod_name=None)
+    assert any("namespace missing" in w for w in ctx.warnings)
+    assert ctx.pod_status is None
+
+
+def test_collect_context_no_core_api_returns_warning() -> None:
+    c = _client(core_api=None)
+    ctx = c.collect_context(namespace="bookinfo", pod_name="test-pod")
+    assert any("not configured" in w for w in ctx.warnings)
+
+
+def test_collect_context_namespace_only_adds_discovery_hint() -> None:
+    core = MagicMock()
+    core.list_namespaced_event.return_value = k8s_client.CoreV1EventList(items=[])
+    c = _client(core_api=core)
+    ctx = c.collect_context(namespace="bookinfo", pod_name=None)
+    assert any("pod_name missing" in w for w in ctx.warnings)
+
+
+def test_collect_context_with_pod_reads_status() -> None:
+    core = MagicMock()
+    pod = _make_pod()
+    core.read_namespaced_pod.return_value = pod
+    core.list_namespaced_event.return_value = k8s_client.CoreV1EventList(items=[])
+    core.read_namespaced_pod_log.return_value = "log line 1\nlog line 2"
+
+    c = _client(core_api=core)
+    ctx = c.collect_context(namespace="bookinfo", pod_name="test-pod")
+
+    assert ctx.pod_status is not None
+    assert ctx.pod_status.phase == "Running"
+    core.read_namespaced_pod.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# get_pod_status
+# ---------------------------------------------------------------------------
+
+
+def test_get_pod_status_no_api_returns_none() -> None:
+    c = _client(core_api=None)
+    assert c.get_pod_status("bookinfo", "test-pod") is None
+
+
+def test_get_pod_status_pod_not_found_returns_none() -> None:
+    core = MagicMock()
+    core.read_namespaced_pod.side_effect = Exception("not found")
+
+    c = _client(core_api=core)
+    result = c.get_pod_status("bookinfo", "test-pod")
+    assert result is None
+
+
+def test_get_pod_status_returns_snapshot() -> None:
+    core = MagicMock()
+    pod = _make_pod(phase="CrashLoopBackOff")
+    core.read_namespaced_pod.return_value = pod
+
+    c = _client(core_api=core)
+    result = c.get_pod_status("bookinfo", "test-pod")
+    assert result is not None
+    assert result.phase == "CrashLoopBackOff"
+
+
+# ---------------------------------------------------------------------------
+# list_pod_events
+# ---------------------------------------------------------------------------
+
+
+def test_list_pod_events_no_api_returns_empty() -> None:
+    c = _client(core_api=None)
+    assert c.list_pod_events("bookinfo", "test-pod") == []
+
+
+def test_list_pod_events_returns_summaries() -> None:
+    core = MagicMock()
+    core.list_namespaced_event.return_value = k8s_client.CoreV1EventList(
+        items=[_make_event(reason="OOMKilling")]
+    )
+
+    c = _client(core_api=core)
+    events = c.list_pod_events("bookinfo", "test-pod")
+
+    assert len(events) == 1
+    assert events[0].reason == "OOMKilling"
+
+
+def test_list_pod_events_api_error_returns_empty() -> None:
+    core = MagicMock()
+    core.list_namespaced_event.side_effect = Exception("API error")
+
+    c = _client(core_api=core)
+    events = c.list_pod_events("bookinfo", "test-pod")
+    assert events == []
+
+
+# ---------------------------------------------------------------------------
+# list_pods_in_namespace
+# ---------------------------------------------------------------------------
+
+
+def test_list_pods_no_api_returns_empty() -> None:
+    c = _client(core_api=None)
+    assert c.list_pods_in_namespace("bookinfo") == []
+
+
+def test_list_pods_returns_summaries() -> None:
+    core = MagicMock()
+    core.list_namespaced_pod.return_value = k8s_client.V1PodList(items=[_make_pod()])
+
+    c = _client(core_api=core)
+    pods = c.list_pods_in_namespace("bookinfo")
+
+    assert len(pods) == 1
+    assert pods[0].name == "test-pod"
+    assert pods[0].namespace == "bookinfo"
+
+
+def test_list_pods_with_label_selector() -> None:
+    core = MagicMock()
+    core.list_namespaced_pod.return_value = k8s_client.V1PodList(items=[_make_pod()])
+
+    c = _client(core_api=core)
+    c.list_pods_in_namespace("bookinfo", label_selector="app=test-pod")
+
+    call_kwargs = core.list_namespaced_pod.call_args.kwargs
+    assert call_kwargs.get("label_selector") == "app=test-pod"
+
+
+def test_list_pods_api_error_returns_empty() -> None:
+    core = MagicMock()
+    core.list_namespaced_pod.side_effect = Exception("timeout")
+
+    c = _client(core_api=core)
+    result = c.list_pods_in_namespace("bookinfo")
+    assert result == []
+
+
+# ---------------------------------------------------------------------------
+# get_previous_logs
+# ---------------------------------------------------------------------------
+
+
+def test_get_previous_logs_no_api_returns_empty() -> None:
+    c = _client(core_api=None)
+    assert c.get_previous_logs("bookinfo", "test-pod") == []
+
+
+def test_get_previous_logs_returns_snippets() -> None:
+    core = MagicMock()
+    pod = _make_pod(containers=["app", "sidecar"])
+    core.read_namespaced_pod.return_value = pod
+    core.read_namespaced_pod_log.return_value = "OOMKilled\nkilled"
+
+    c = _client(core_api=core)
+    snippets = c.get_previous_logs("bookinfo", "test-pod")
+
+    assert len(snippets) == 2
+    assert all(s.previous for s in snippets)
+    assert snippets[0].container == "app"
+
+
+def test_get_previous_logs_api_error_returns_snippet_with_error() -> None:
+    core = MagicMock()
+    pod = _make_pod(containers=["app"])
+    core.read_namespaced_pod.return_value = pod
+    core.read_namespaced_pod_log.side_effect = Exception("not found")
+
+    c = _client(core_api=core)
+    snippets = c.get_previous_logs("bookinfo", "test-pod")
+
+    assert len(snippets) == 1
+    assert snippets[0].error is not None
+
+
+# ---------------------------------------------------------------------------
+# get_node_status
+# ---------------------------------------------------------------------------
+
+
+def test_get_node_status_no_api_returns_none() -> None:
+    c = _client(core_api=None)
+    assert c.get_node_status("node-1") is None
+
+
+def test_get_node_status_returns_dict() -> None:
+    core = MagicMock()
+    node = k8s_client.V1Node(
+        metadata=k8s_client.V1ObjectMeta(name="node-1", labels={"role": "worker"}),
+        spec=k8s_client.V1NodeSpec(unschedulable=False, taints=[]),
+        status=k8s_client.V1NodeStatus(
+            conditions=[
+                k8s_client.V1NodeCondition(
+                    type="Ready",
+                    status="True",
+                    reason="KubeletReady",
+                    message="kubelet is posting ready status",
+                )
+            ],
+            capacity={"cpu": "4", "memory": "8Gi"},
+            allocatable={"cpu": "3900m", "memory": "7Gi"},
+        ),
+    )
+    core.read_node.return_value = node
+
+    c = _client(core_api=core)
+    result = c.get_node_status("node-1")
+
+    assert result is not None
+    assert result["name"] == "node-1"
+    assert result["unschedulable"] is False
+    assert len(result["conditions"]) == 1
+    assert result["conditions"][0]["type"] == "Ready"  # type: ignore[index]
+
+
+def test_get_node_status_api_error_returns_none() -> None:
+    core = MagicMock()
+    core.read_node.side_effect = Exception("unauthorized")
+
+    c = _client(core_api=core)
+    assert c.get_node_status("node-1") is None
+
+
+# ---------------------------------------------------------------------------
+# namespace events — v1 path (nosec B112 line coverage)
+# ---------------------------------------------------------------------------
+
+
+def test_list_namespace_events_v1_parses_raw_json() -> None:
+    core = MagicMock()
+    events_api = MagicMock()
+
+    items_payload = [
+        {
+            "reason": "OOMKilling",
+            "note": "OOM killed",
+            "type": "Warning",
+            "metadata": {"name": "e1", "namespace": "bookinfo"},
+            "regarding": {"kind": "Pod", "name": "test-pod", "namespace": "bookinfo"},
+            "series": None,
+            "reportingComponent": "",
+        }
+    ]
+    raw_response = MagicMock()
+    raw_response.data = json.dumps({"items": items_payload}).encode()
+    events_api.list_namespaced_event.return_value = raw_response
+
+    c = _client(core_api=core, events_api=events_api)
+    result = c.list_namespace_events("bookinfo")
+
+    assert len(result) >= 1
+
+
+def test_list_namespace_events_v1_drops_malformed_items() -> None:
+    """Covers the nosec B112 branch: malformed items are silently dropped."""
+    core = MagicMock()
+    events_api = MagicMock()
+
+    items_payload = [
+        None,  # malformed — will raise during _to_event_summary_v1_raw
+        {
+            "reason": "Pulled",
+            "note": "Successfully pulled image",
+            "type": "Normal",
+            "metadata": {"name": "e2", "namespace": "bookinfo"},
+            "regarding": {"kind": "Pod", "name": "test-pod", "namespace": "bookinfo"},
+        },
+    ]
+    raw_response = MagicMock()
+    raw_response.data = json.dumps({"items": items_payload}).encode()
+    events_api.list_namespaced_event.return_value = raw_response
+
+    c = _client(core_api=core, events_api=events_api)
+    # Should not raise; malformed item is skipped
+    result = c.list_namespace_events("bookinfo")
+    assert isinstance(result, list)
+
+
+def test_list_namespace_events_v1_api_error_falls_back_to_core() -> None:
+    core = MagicMock()
+    core.list_namespaced_event.return_value = k8s_client.CoreV1EventList(items=[])
+    events_api = MagicMock()
+    events_api.list_namespaced_event.side_effect = Exception("API unavailable")
+
+    c = _client(core_api=core, events_api=events_api)
+    result = c.list_namespace_events("bookinfo")
+    assert isinstance(result, list)
+
+
+# ---------------------------------------------------------------------------
+# _sanitize_manifest_for_read — masking
+# ---------------------------------------------------------------------------
+
+
+def test_sanitize_manifest_masks_secret_data() -> None:
+    payload: dict[str, Any] = {
+        "apiVersion": "v1",
+        "kind": "Secret",
+        "metadata": {"name": "my-secret", "namespace": "default", "managedFields": ["noise"]},
+        "data": {"token": "c2VjcmV0", "password": "cGFzc3dvcmQ="},
+        "status": {"some": "field"},
+    }
+    result = KubernetesClient._sanitize_manifest_for_read(payload, resource="secrets")
+
+    assert result["data"] == {"token": "[MASKED]", "password": "[MASKED]"}  # type: ignore[comparison-overlap]
+    assert "status" not in result
+    assert "managedFields" not in result["metadata"]  # type: ignore[operator]
+
+
+def test_sanitize_manifest_strips_managed_fields_non_secret() -> None:
+    payload: dict[str, Any] = {
+        "apiVersion": "apps/v1",
+        "kind": "Deployment",
+        "metadata": {"name": "my-deploy", "managedFields": ["noisy"]},
+        "spec": {"replicas": 3},
+        "status": {"readyReplicas": 3},
+    }
+    result = KubernetesClient._sanitize_manifest_for_read(payload, resource="deployments")
+
+    assert "status" not in result
+    assert "managedFields" not in result["metadata"]  # type: ignore[operator]
+    assert result["spec"] == {"replicas": 3}  # type: ignore[comparison-overlap]
+
+
+# ---------------------------------------------------------------------------
+# _parse_api_version
+# ---------------------------------------------------------------------------
+
+
+def test_parse_api_version_core() -> None:
+    assert KubernetesClient._parse_api_version("v1") == (None, "v1")
+
+
+def test_parse_api_version_group() -> None:
+    assert KubernetesClient._parse_api_version("apps/v1") == ("apps", "v1")
+
+
+def test_parse_api_version_empty_returns_none() -> None:
+    assert KubernetesClient._parse_api_version("") is None
+
+
+def test_parse_api_version_invalid_group_returns_none() -> None:
+    assert KubernetesClient._parse_api_version("/v1") is None
+
+
+# ---------------------------------------------------------------------------
+# get_workload_summary — deployment path
+# ---------------------------------------------------------------------------
+
+
+def test_get_workload_summary_deployment() -> None:
+    core = MagicMock()
+    apps = MagicMock()
+
+    pod = _make_pod(owner_kind="ReplicaSet", owner_name="test-rs")
+    core.read_namespaced_pod.return_value = pod
+
+    rs = k8s_client.V1ReplicaSet(
+        metadata=k8s_client.V1ObjectMeta(
+            name="test-rs",
+            namespace="bookinfo",
+            owner_references=[
+                k8s_client.V1OwnerReference(
+                    api_version="apps/v1",
+                    kind="Deployment",
+                    name="test-deploy",
+                    uid="uid-2",
+                    controller=True,
+                )
+            ],
+        ),
+        status=k8s_client.V1ReplicaSetStatus(replicas=1, ready_replicas=1),
+    )
+    apps.read_namespaced_replica_set.return_value = rs
+
+    deployment = k8s_client.V1Deployment(
+        metadata=k8s_client.V1ObjectMeta(
+            name="test-deploy",
+            namespace="bookinfo",
+            generation=1,
+        ),
+        status=k8s_client.V1DeploymentStatus(
+            replicas=1,
+            ready_replicas=1,
+            updated_replicas=1,
+            available_replicas=1,
+        ),
+    )
+    apps.read_namespaced_deployment.return_value = deployment
+
+    c = _client(core_api=core, apps_api=apps)
+    result = c.get_workload_summary("bookinfo", "test-pod")
+
+    assert result is not None
+    assert result["kind"] == "Deployment"
+    assert result["name"] == "test-deploy"
+
+
+def test_get_workload_summary_no_apis_returns_none() -> None:
+    c = _client(core_api=None, apps_api=None, batch_api=None)
+    assert c.get_workload_summary("bookinfo", "test-pod") is None
+
+
+# ---------------------------------------------------------------------------
+# collect_context with node_name
+# ---------------------------------------------------------------------------
+
+
+def test_collect_context_node_not_found_adds_warning() -> None:
+    core = MagicMock()
+    core.read_node.side_effect = Exception("not found")
+
+    c = _client(core_api=core)
+    ctx = c.collect_context(namespace=None, pod_name=None, node_name="missing-node")
+
+    # node_name provided, so no "namespace missing" early return
+    assert any("not found" in w or "inaccessible" in w for w in ctx.warnings)
+
+
+# ---------------------------------------------------------------------------
+# get_pod_logs
+# ---------------------------------------------------------------------------
+
+
+def test_get_pod_logs_no_api_returns_empty() -> None:
+    c = _client(core_api=None)
+    assert c.get_pod_logs("bookinfo", "test-pod") == []
+
+
+def test_get_pod_logs_returns_snippets() -> None:
+    core = MagicMock()
+    pod = _make_pod(containers=["app"])
+    core.read_namespaced_pod.return_value = pod
+    core.read_namespaced_pod_log.return_value = "line1\nline2"
+
+    c = _client(core_api=core)
+    snippets = c.get_pod_logs("bookinfo", "test-pod")
+
+    assert len(snippets) == 1
+    assert snippets[0].logs == ["line1", "line2"]
+    assert not snippets[0].previous
+
+
+def test_get_pod_logs_specific_container() -> None:
+    core = MagicMock()
+    pod = _make_pod(containers=["app", "sidecar"])
+    core.read_namespaced_pod.return_value = pod
+    core.read_namespaced_pod_log.return_value = "output"
+
+    c = _client(core_api=core)
+    snippets = c.get_pod_logs("bookinfo", "test-pod", container="sidecar")
+
+    assert len(snippets) == 1
+    assert snippets[0].container == "sidecar"
+
+
+def test_get_pod_logs_api_error_returns_snippet_with_error() -> None:
+    core = MagicMock()
+    pod = _make_pod(containers=["app"])
+    core.read_namespaced_pod.return_value = pod
+    core.read_namespaced_pod_log.side_effect = Exception("forbidden")
+
+    c = _client(core_api=core)
+    snippets = c.get_pod_logs("bookinfo", "test-pod")
+
+    assert len(snippets) == 1
+    assert snippets[0].error is not None
+
+
+# ---------------------------------------------------------------------------
+# list_services_by_label
+# ---------------------------------------------------------------------------
+
+
+def test_list_services_no_api_returns_empty() -> None:
+    c = _client(core_api=None)
+    assert c.list_services_by_label("app=nginx") == []
+
+
+def test_list_services_empty_selector_returns_empty() -> None:
+    c = _client(core_api=MagicMock())
+    assert c.list_services_by_label("") == []
+
+
+def test_list_services_all_namespaces() -> None:
+    core = MagicMock()
+    svc = k8s_client.V1Service(
+        metadata=k8s_client.V1ObjectMeta(name="my-svc", namespace="bookinfo")
+    )
+    core.list_service_for_all_namespaces.return_value = k8s_client.V1ServiceList(items=[svc])
+
+    c = _client(core_api=core)
+    result = c.list_services_by_label("app=nginx")
+
+    assert len(result) == 1
+    core.list_service_for_all_namespaces.assert_called_once()
+
+
+def test_list_services_specific_namespaces() -> None:
+    core = MagicMock()
+    svc = k8s_client.V1Service(
+        metadata=k8s_client.V1ObjectMeta(name="my-svc", namespace="bookinfo")
+    )
+    core.list_namespaced_service.return_value = k8s_client.V1ServiceList(items=[svc])
+
+    c = _client(core_api=core)
+    result = c.list_services_by_label("app=nginx", namespaces=["bookinfo"])
+
+    assert len(result) == 1
+    core.list_namespaced_service.assert_called_once()
+
+
+def test_list_services_api_error_returns_empty() -> None:
+    core = MagicMock()
+    core.list_service_for_all_namespaces.side_effect = Exception("timeout")
+
+    c = _client(core_api=core)
+    result = c.list_services_by_label("app=nginx")
+    assert result == []
+
+
+# ---------------------------------------------------------------------------
+# get_pod_spec_summary
+# ---------------------------------------------------------------------------
+
+
+def test_get_pod_spec_summary_no_api_returns_none() -> None:
+    c = _client(core_api=None)
+    assert c.get_pod_spec_summary("bookinfo", "test-pod") is None
+
+
+def test_get_pod_spec_summary_pod_not_found_returns_none() -> None:
+    core = MagicMock()
+    core.read_namespaced_pod.side_effect = Exception("not found")
+
+    c = _client(core_api=core)
+    assert c.get_pod_spec_summary("bookinfo", "test-pod") is None
+
+
+def test_get_pod_spec_summary_returns_dict() -> None:
+    core = MagicMock()
+    pod = _make_pod(containers=["app"])
+    core.read_namespaced_pod.return_value = pod
+
+    c = _client(core_api=core)
+    result = c.get_pod_spec_summary("bookinfo", "test-pod")
+
+    assert result is not None
+    assert "containers" in result
+    assert result["node_name"] == "node-1"
+
+
+# ---------------------------------------------------------------------------
+# get_workload_summary — StatefulSet / DaemonSet / error paths
+# ---------------------------------------------------------------------------
+
+
+def test_get_workload_summary_stateful_set() -> None:
+    core = MagicMock()
+    apps = MagicMock()
+
+    pod = _make_pod(owner_kind="StatefulSet", owner_name="test-ss")
+    core.read_namespaced_pod.return_value = pod
+
+    ss = k8s_client.V1StatefulSet(
+        metadata=k8s_client.V1ObjectMeta(
+            name="test-ss",
+            namespace="bookinfo",
+            owner_references=[],
+        ),
+        status=k8s_client.V1StatefulSetStatus(
+            replicas=1,
+            ready_replicas=1,
+            current_replicas=1,
+            observed_generation=1,
+        ),
+    )
+    apps.read_namespaced_stateful_set.return_value = ss
+
+    c = _client(core_api=core, apps_api=apps)
+    result = c.get_workload_summary("bookinfo", "test-pod")
+
+    assert result is not None
+    assert result["kind"] == "StatefulSet"
+
+
+def test_get_workload_summary_daemon_set() -> None:
+    core = MagicMock()
+    apps = MagicMock()
+
+    pod = _make_pod(owner_kind="DaemonSet", owner_name="test-ds")
+    core.read_namespaced_pod.return_value = pod
+
+    ds = k8s_client.V1DaemonSet(
+        metadata=k8s_client.V1ObjectMeta(
+            name="test-ds",
+            namespace="bookinfo",
+            owner_references=[],
+        ),
+        status=k8s_client.V1DaemonSetStatus(
+            number_ready=1,
+            desired_number_scheduled=1,
+            current_number_scheduled=1,
+            number_misscheduled=0,
+        ),
+    )
+    apps.read_namespaced_daemon_set.return_value = ds
+
+    c = _client(core_api=core, apps_api=apps)
+    result = c.get_workload_summary("bookinfo", "test-pod")
+
+    assert result is not None
+    assert result["kind"] == "DaemonSet"
+
+
+def test_get_workload_summary_pod_not_found_returns_none() -> None:
+    core = MagicMock()
+    apps = MagicMock()
+    core.read_namespaced_pod.side_effect = Exception("not found")
+
+    c = _client(core_api=core, apps_api=apps)
+    assert c.get_workload_summary("bookinfo", "test-pod") is None
+
+
+def test_get_workload_summary_no_owner_returns_none() -> None:
+    core = MagicMock()
+    apps = MagicMock()
+    pod = _make_pod()  # no owner references
+    core.read_namespaced_pod.return_value = pod
+
+    c = _client(core_api=core, apps_api=apps)
+    assert c.get_workload_summary("bookinfo", "test-pod") is None
+
+
+# ---------------------------------------------------------------------------
+# get_manifest / list_manifests — custom resource path
+# ---------------------------------------------------------------------------
+
+
+def test_get_manifest_custom_resource() -> None:
+    custom = MagicMock()
+    payload = {
+        "apiVersion": "chaos-mesh.org/v1alpha1",
+        "kind": "PodChaos",
+        "metadata": {"name": "my-chaos", "namespace": "bookinfo"},
+        "spec": {"action": "pod-kill"},
+    }
+    custom.get_namespaced_custom_object.return_value = payload
+
+    c = _client(custom_api=custom)
+    result = c.get_manifest(
+        namespace="bookinfo",
+        api_version="chaos-mesh.org/v1alpha1",
+        resource="podchaos",
+        name="my-chaos",
+    )
+
+    assert result is not None
+    custom.get_namespaced_custom_object.assert_called_once()
+
+
+def test_get_manifest_invalid_api_version_returns_none() -> None:
+    c = _client()
+    result = c.get_manifest(
+        namespace="bookinfo",
+        api_version="",
+        resource="pods",
+        name="test-pod",
+    )
+    assert result is None
+
+
+def test_list_manifests_custom_resource() -> None:
+    custom = MagicMock()
+    custom.list_namespaced_custom_object.return_value = {
+        "items": [
+            {
+                "apiVersion": "chaos-mesh.org/v1alpha1",
+                "kind": "PodChaos",
+                "metadata": {"name": "chaos-1"},
+                "spec": {"action": "pod-kill"},
+            }
+        ]
+    }
+
+    c = _client(custom_api=custom)
+    results = c.list_manifests(
+        namespace="bookinfo",
+        api_version="chaos-mesh.org/v1alpha1",
+        resource="podchaos",
+    )
+
+    assert len(results) == 1
+
+
+def test_list_manifests_empty_resource_returns_empty() -> None:
+    c = _client()
+    assert c.list_manifests(namespace="bookinfo", api_version="v1", resource="") == []
+
+
+# ---------------------------------------------------------------------------
+# cluster events
+# ---------------------------------------------------------------------------
+
+
+def test_list_cluster_events_v1_fallback_to_core() -> None:
+    core = MagicMock()
+    core.list_event_for_all_namespaces.return_value = k8s_client.CoreV1EventList(
+        items=[_make_event()]
+    )
+    events_api = MagicMock()
+    events_api.list_event_for_all_namespaces.side_effect = Exception("unavailable")
+
+    c = _client(core_api=core, events_api=events_api)
+    result = c.list_cluster_events()
+
+    assert isinstance(result, list)
+    assert len(result) >= 1
+
+
+def test_list_cluster_events_no_apis_returns_empty() -> None:
+    c = _client(core_api=None, events_api=None)
+    assert c.list_cluster_events() == []
+
+
+# ---------------------------------------------------------------------------
+# get_pod_metrics
+# ---------------------------------------------------------------------------
+
+
+def test_get_pod_metrics_no_api_returns_none() -> None:
+    c = _client(custom_api=None)
+    assert c.get_pod_metrics("bookinfo", "test-pod") is None
+
+
+def test_get_pod_metrics_api_error_returns_none() -> None:
+    custom = MagicMock()
+    custom.get_namespaced_custom_object.side_effect = Exception("not found")
+
+    c = _client(custom_api=custom)
+    assert c.get_pod_metrics("bookinfo", "test-pod") is None

--- a/agent/tests/test_prometheus_client.py
+++ b/agent/tests/test_prometheus_client.py
@@ -1,0 +1,348 @@
+from __future__ import annotations
+
+import json
+import urllib.error
+import urllib.parse
+
+import pytest
+
+import app.clients.prometheus as prometheus_module
+from app.clients.prometheus import PrometheusClient
+from app.core.config import load_settings
+
+_METRICS_URL = "http://prometheus.monitoring.svc:9090"
+
+
+class _FakePrometheusResponse:
+    def __init__(self, body: str) -> None:
+        self._body = body.encode("utf-8")
+
+    def read(self) -> bytes:
+        return self._body
+
+    def __enter__(self) -> _FakePrometheusResponse:
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:  # type: ignore[no-untyped-def]
+        return None
+
+
+def _install_fake_urlopen(
+    monkeypatch: pytest.MonkeyPatch,
+    body: str = '{"status":"success","data":[]}',
+) -> dict[str, object]:
+    captured: dict[str, object] = {}
+
+    def fake_urlopen(request, timeout=0):  # type: ignore[no-untyped-def]
+        captured["url"] = request if isinstance(request, str) else request.full_url
+        captured["timeout"] = timeout
+        return _FakePrometheusResponse(body)
+
+    monkeypatch.setattr(prometheus_module.urllib.request, "urlopen", fake_urlopen)
+    return captured
+
+
+# ---------------------------------------------------------------------------
+# enabled / disabled
+# ---------------------------------------------------------------------------
+
+
+def test_disabled_when_no_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("PROMETHEUS_URL", raising=False)
+    client = PrometheusClient(load_settings())
+    assert not client.enabled
+
+
+def test_enabled_when_url_set(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("PROMETHEUS_URL", _METRICS_URL)
+    client = PrometheusClient(load_settings())
+    assert client.enabled
+
+
+def test_describe_endpoint_returns_base_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("PROMETHEUS_URL", _METRICS_URL)
+    client = PrometheusClient(load_settings())
+    result = client.describe_endpoint()
+    assert result["endpoint"]["base_url"] == _METRICS_URL  # type: ignore[index]
+
+
+def test_describe_endpoint_disabled_returns_warning(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("PROMETHEUS_URL", raising=False)
+    client = PrometheusClient(load_settings())
+    result = client.describe_endpoint()
+    assert "warning" in result
+
+
+# ---------------------------------------------------------------------------
+# list_metrics
+# ---------------------------------------------------------------------------
+
+
+def test_list_metrics_not_configured(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("PROMETHEUS_URL", raising=False)
+    client = PrometheusClient(load_settings())
+    result = client.list_metrics()
+    assert "warning" in result
+
+
+def test_list_metrics_no_match(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("PROMETHEUS_URL", _METRICS_URL)
+    body = json.dumps({"status": "success", "data": ["up", "kube_pod_status_phase"]})
+    captured = _install_fake_urlopen(monkeypatch, body=body)
+
+    client = PrometheusClient(load_settings())
+    result = client.list_metrics()
+
+    parsed = urllib.parse.urlparse(str(captured["url"]))
+    assert parsed.path == "/api/v1/label/__name__/values"
+    assert result["count"] == 2
+    assert "up" in result["metrics"]  # type: ignore[operator]
+
+
+def test_list_metrics_with_regex_match(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("PROMETHEUS_URL", _METRICS_URL)
+    body = json.dumps(
+        {
+            "status": "success",
+            "data": ["up", "kube_pod_status_phase", "kube_node_status_condition"],
+        }
+    )
+    _install_fake_urlopen(monkeypatch, body=body)
+
+    client = PrometheusClient(load_settings())
+    result = client.list_metrics(match="kube_pod.*")
+
+    assert result["count"] == 1
+    assert result["metrics"] == ["kube_pod_status_phase"]  # type: ignore[comparison-overlap]
+
+
+def test_list_metrics_invalid_regex(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("PROMETHEUS_URL", _METRICS_URL)
+    body = json.dumps({"status": "success", "data": ["up"]})
+    _install_fake_urlopen(monkeypatch, body=body)
+
+    client = PrometheusClient(load_settings())
+    result = client.list_metrics(match="[invalid(")
+
+    assert result["error"] == "invalid regex pattern"
+    assert "pattern" in result
+
+
+def test_list_metrics_http_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("PROMETHEUS_URL", _METRICS_URL)
+
+    def fake_urlopen(request, timeout=0):  # type: ignore[no-untyped-def]
+        raise urllib.error.HTTPError(
+            url=str(request.full_url),
+            code=503,
+            msg="Service Unavailable",
+            hdrs=None,  # type: ignore[arg-type]
+            fp=None,
+        )
+
+    monkeypatch.setattr(prometheus_module.urllib.request, "urlopen", fake_urlopen)
+
+    client = PrometheusClient(load_settings())
+    result = client.list_metrics()
+
+    assert result["error"] == "failed to list Prometheus metrics"
+    assert "endpoint" in result
+
+
+def test_list_metrics_json_decode_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("PROMETHEUS_URL", _METRICS_URL)
+    _install_fake_urlopen(monkeypatch, body="not-json{{")
+
+    client = PrometheusClient(load_settings())
+    result = client.list_metrics()
+
+    assert result["error"] == "failed to decode Prometheus response"
+    assert "endpoint" in result
+
+
+# ---------------------------------------------------------------------------
+# query
+# ---------------------------------------------------------------------------
+
+
+def test_query_not_configured(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("PROMETHEUS_URL", raising=False)
+    client = PrometheusClient(load_settings())
+    result = client.query("up")
+    assert "warning" in result
+
+
+def test_query_sends_correct_path_and_param(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("PROMETHEUS_URL", _METRICS_URL)
+    body = json.dumps({"status": "success", "data": {"resultType": "vector", "result": []}})
+    captured = _install_fake_urlopen(monkeypatch, body=body)
+
+    client = PrometheusClient(load_settings())
+    client.query("up")
+
+    parsed = urllib.parse.urlparse(str(captured["url"]))
+    params = urllib.parse.parse_qs(parsed.query)
+    assert parsed.path == "/api/v1/query"
+    assert params["query"] == ["up"]
+
+
+def test_query_with_time_param(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("PROMETHEUS_URL", _METRICS_URL)
+    body = json.dumps({"status": "success", "data": {"resultType": "vector", "result": []}})
+    captured = _install_fake_urlopen(monkeypatch, body=body)
+
+    client = PrometheusClient(load_settings())
+    client.query("up", time="1770402600")
+
+    params = urllib.parse.parse_qs(urllib.parse.urlparse(str(captured["url"])).query)
+    assert params["time"] == ["1770402600"]
+
+
+def test_query_http_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("PROMETHEUS_URL", _METRICS_URL)
+
+    def fake_urlopen(request, timeout=0):  # type: ignore[no-untyped-def]
+        raise urllib.error.HTTPError(
+            url=str(request.full_url),
+            code=429,
+            msg="Too Many Requests",
+            hdrs=None,  # type: ignore[arg-type]
+            fp=None,
+        )
+
+    monkeypatch.setattr(prometheus_module.urllib.request, "urlopen", fake_urlopen)
+
+    client = PrometheusClient(load_settings())
+    result = client.query("up")
+
+    assert result["error"] == "failed to query Prometheus"
+    assert "endpoint" in result
+
+
+def test_query_json_decode_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("PROMETHEUS_URL", _METRICS_URL)
+    _install_fake_urlopen(monkeypatch, body="not-json{{{")
+
+    client = PrometheusClient(load_settings())
+    result = client.query("up")
+
+    assert result["error"] == "failed to decode Prometheus response"
+    assert "raw" in result
+    assert "endpoint" in result
+
+
+def test_query_connection_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("PROMETHEUS_URL", _METRICS_URL)
+
+    def fake_urlopen(request, timeout=0):  # type: ignore[no-untyped-def]
+        raise ConnectionError("connection refused")
+
+    monkeypatch.setattr(prometheus_module.urllib.request, "urlopen", fake_urlopen)
+
+    client = PrometheusClient(load_settings())
+    result = client.query("up")
+
+    assert result["error"] == "failed to query Prometheus"
+    assert "connection refused" in str(result["detail"])
+
+
+# ---------------------------------------------------------------------------
+# query_range
+# ---------------------------------------------------------------------------
+
+
+def test_query_range_not_configured(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("PROMETHEUS_URL", raising=False)
+    client = PrometheusClient(load_settings())
+    result = client.query_range("up", start="1770402600", end="1770403200")
+    assert "warning" in result
+
+
+def test_query_range_sends_correct_params(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("PROMETHEUS_URL", _METRICS_URL)
+    body = json.dumps({"status": "success", "data": {"resultType": "matrix", "result": []}})
+    captured = _install_fake_urlopen(monkeypatch, body=body)
+
+    client = PrometheusClient(load_settings())
+    client.query_range(
+        'rate(http_requests_total{namespace="bookinfo"}[5m])',
+        start="1770402600",
+        end="1770403200",
+        step="30s",
+    )
+
+    parsed = urllib.parse.urlparse(str(captured["url"]))
+    params = urllib.parse.parse_qs(parsed.query)
+    assert parsed.path == "/api/v1/query_range"
+    assert params["start"] == ["1770402600"]
+    assert params["end"] == ["1770403200"]
+    assert params["step"] == ["30s"]
+
+
+def test_query_range_default_step(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("PROMETHEUS_URL", _METRICS_URL)
+    body = json.dumps({"status": "success", "data": {"resultType": "matrix", "result": []}})
+    captured = _install_fake_urlopen(monkeypatch, body=body)
+
+    client = PrometheusClient(load_settings())
+    client.query_range("up", start="1770402600", end="1770403200")
+
+    params = urllib.parse.parse_qs(urllib.parse.urlparse(str(captured["url"])).query)
+    assert params["step"] == ["1m"]
+
+
+def test_query_range_http_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("PROMETHEUS_URL", _METRICS_URL)
+
+    def fake_urlopen(request, timeout=0):  # type: ignore[no-untyped-def]
+        raise urllib.error.HTTPError(
+            url=str(request.full_url),
+            code=500,
+            msg="Internal Server Error",
+            hdrs=None,  # type: ignore[arg-type]
+            fp=None,
+        )
+
+    monkeypatch.setattr(prometheus_module.urllib.request, "urlopen", fake_urlopen)
+
+    client = PrometheusClient(load_settings())
+    result = client.query_range("up", start="1770402600", end="1770403200")
+
+    assert result["error"] == "failed to query_range Prometheus"
+    assert "endpoint" in result
+
+
+def test_query_range_json_decode_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("PROMETHEUS_URL", _METRICS_URL)
+    _install_fake_urlopen(monkeypatch, body="bad-json")
+
+    client = PrometheusClient(load_settings())
+    result = client.query_range("up", start="1770402600", end="1770403200")
+
+    assert result["error"] == "failed to decode Prometheus response"
+    assert "raw" in result
+
+
+# ---------------------------------------------------------------------------
+# URL normalisation edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_trailing_slash_stripped(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("PROMETHEUS_URL", _METRICS_URL + "/")
+    client = PrometheusClient(load_settings())
+    assert client.enabled
+    result = client.describe_endpoint()
+    assert not str(result["endpoint"]["base_url"]).endswith("/")  # type: ignore[index]
+
+
+def test_scheme_added_when_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("PROMETHEUS_URL", "prometheus.monitoring.svc:9090")
+    client = PrometheusClient(load_settings())
+    assert client.enabled
+
+
+def test_invalid_scheme_disables_client(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("PROMETHEUS_URL", "ftp://prometheus.monitoring.svc:9090")
+    client = PrometheusClient(load_settings())
+    assert not client.enabled

--- a/agent/tests/test_prometheus_client.py
+++ b/agent/tests/test_prometheus_client.py
@@ -23,7 +23,7 @@ class _FakePrometheusResponse:
     def __enter__(self) -> _FakePrometheusResponse:
         return self
 
-    def __exit__(self, exc_type, exc, tb) -> None:  # type: ignore[no-untyped-def]
+    def __exit__(self, _exc_type, _exc, _tb) -> None:  # type: ignore[no-untyped-def]
         return None
 
 
@@ -131,7 +131,7 @@ def test_list_metrics_invalid_regex(monkeypatch: pytest.MonkeyPatch) -> None:
 def test_list_metrics_http_error(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("PROMETHEUS_URL", _METRICS_URL)
 
-    def fake_urlopen(request, timeout=0):  # type: ignore[no-untyped-def]
+    def fake_urlopen(request, timeout=0):  # type: ignore[no-untyped-def]  # noqa: ARG001
         raise urllib.error.HTTPError(
             url=str(request.full_url),
             code=503,
@@ -201,7 +201,7 @@ def test_query_with_time_param(monkeypatch: pytest.MonkeyPatch) -> None:
 def test_query_http_error(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("PROMETHEUS_URL", _METRICS_URL)
 
-    def fake_urlopen(request, timeout=0):  # type: ignore[no-untyped-def]
+    def fake_urlopen(request, timeout=0):  # type: ignore[no-untyped-def]  # noqa: ARG001
         raise urllib.error.HTTPError(
             url=str(request.full_url),
             code=429,
@@ -234,7 +234,7 @@ def test_query_json_decode_error(monkeypatch: pytest.MonkeyPatch) -> None:
 def test_query_connection_error(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("PROMETHEUS_URL", _METRICS_URL)
 
-    def fake_urlopen(request, timeout=0):  # type: ignore[no-untyped-def]
+    def fake_urlopen(_request, timeout=0):  # type: ignore[no-untyped-def]  # noqa: ARG001
         raise ConnectionError("connection refused")
 
     monkeypatch.setattr(prometheus_module.urllib.request, "urlopen", fake_urlopen)
@@ -294,7 +294,7 @@ def test_query_range_default_step(monkeypatch: pytest.MonkeyPatch) -> None:
 def test_query_range_http_error(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("PROMETHEUS_URL", _METRICS_URL)
 
-    def fake_urlopen(request, timeout=0):  # type: ignore[no-untyped-def]
+    def fake_urlopen(request, timeout=0):  # type: ignore[no-untyped-def]  # noqa: ARG001
         raise urllib.error.HTTPError(
             url=str(request.full_url),
             code=500,

--- a/agent/tests/test_session_repository.py
+++ b/agent/tests/test_session_repository.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import threading
+import time
+from collections.abc import Generator
 
 import psycopg
 import pytest
@@ -15,17 +17,33 @@ from app.clients.session_repository import PostgresSessionRepository
 # ---------------------------------------------------------------------------
 
 _PG_IMAGE = "pgvector/pgvector:pg16"
+_CONNECT_RETRIES = 10
+_CONNECT_INTERVAL = 0.5
+
+
+def _wait_and_connect(url: str) -> psycopg.Connection:  # type: ignore[type-arg]
+    """Retry psycopg.connect until the container is fully ready."""
+    last_exc: Exception = RuntimeError("unreachable")
+    for _ in range(_CONNECT_RETRIES):
+        try:
+            return psycopg.connect(url, connect_timeout=5)
+        except Exception as exc:  # noqa: BLE001
+            last_exc = exc
+            time.sleep(_CONNECT_INTERVAL)
+    raise last_exc
 
 
 @pytest.fixture(scope="session")
-def pg_dsn() -> str:  # type: ignore[return]
+def pg_dsn() -> Generator[str, None, None]:
     """Start a PostgreSQL container once per test session and yield a psycopg DSN."""
     with PostgresContainer(image=_PG_IMAGE, driver=None) as pg:
         # get_connection_url with driver=None gives a plain postgresql:// URL.
         # psycopg.connect accepts postgresql:// URIs directly.
         url = pg.get_connection_url()
         # Ensure pgvector extension exists (used by the broader app stack, not repo itself).
-        with psycopg.connect(url) as conn:
+        # Retry loop guards against the container being ready per testcontainers'
+        # psql wait strategy but PostgreSQL not yet accepting TCP connections.
+        with _wait_and_connect(url) as conn:
             conn.execute("CREATE EXTENSION IF NOT EXISTS vector")
             conn.commit()
         # Bootstrap the schema once; individual tests call _clean() for isolation.

--- a/agent/tests/test_session_repository.py
+++ b/agent/tests/test_session_repository.py
@@ -1,0 +1,385 @@
+from __future__ import annotations
+
+import threading
+
+import psycopg
+import pytest
+from strands.types.exceptions import SessionException
+from strands.types.session import Session, SessionAgent, SessionMessage, SessionType
+from testcontainers.postgres import PostgresContainer
+
+from app.clients.session_repository import PostgresSessionRepository
+
+# ---------------------------------------------------------------------------
+# Session-scoped container fixture
+# ---------------------------------------------------------------------------
+
+_PG_IMAGE = "pgvector/pgvector:pg16"
+
+
+@pytest.fixture(scope="session")
+def pg_dsn() -> str:  # type: ignore[return]
+    """Start a PostgreSQL container once per test session and yield a psycopg DSN."""
+    with PostgresContainer(image=_PG_IMAGE, driver=None) as pg:
+        # get_connection_url with driver=None gives a plain postgresql:// URL.
+        # psycopg.connect accepts postgresql:// URIs directly.
+        url = pg.get_connection_url()
+        # Ensure pgvector extension exists (used by the broader app stack, not repo itself).
+        with psycopg.connect(url) as conn:
+            conn.execute("CREATE EXTENSION IF NOT EXISTS vector")
+            conn.commit()
+        # Bootstrap the schema once; individual tests call _clean() for isolation.
+        PostgresSessionRepository(dsn=url)
+        yield url
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _repo(dsn: str) -> PostgresSessionRepository:
+    return PostgresSessionRepository(dsn=dsn)
+
+
+def _session(session_id: str = "sess-1") -> Session:
+    return Session(session_id=session_id, session_type=SessionType.AGENT)
+
+
+def _agent(agent_id: str = "agent-1") -> SessionAgent:
+    return SessionAgent(agent_id=agent_id, state={}, conversation_manager_state={})
+
+
+def _message(message_id: int = 0) -> SessionMessage:
+    msg = {"role": "user", "content": [{"type": "text", "text": "hello"}]}
+    return SessionMessage(message=msg, message_id=message_id)
+
+
+def _clean(dsn: str) -> None:
+    """Truncate all strands tables for test isolation."""
+    with psycopg.connect(dsn) as conn:
+        conn.execute("TRUNCATE strands_messages, strands_agents, strands_sessions CASCADE")
+        conn.commit()
+
+
+# ---------------------------------------------------------------------------
+# create_session / read_session / delete_session
+# ---------------------------------------------------------------------------
+
+
+def test_create_and_read_session(pg_dsn: str) -> None:
+    _clean(pg_dsn)
+    repo = _repo(pg_dsn)
+
+    session = _session("sess-create-read")
+    repo.create_session(session)
+    result = repo.read_session("sess-create-read")
+
+    assert result is not None
+    assert result.session_id == "sess-create-read"
+
+
+def test_read_session_missing_returns_none(pg_dsn: str) -> None:
+    _clean(pg_dsn)
+    repo = _repo(pg_dsn)
+    assert repo.read_session("does-not-exist") is None
+
+
+def test_create_session_duplicate_raises(pg_dsn: str) -> None:
+    _clean(pg_dsn)
+    repo = _repo(pg_dsn)
+    session = _session("sess-dup")
+    repo.create_session(session)
+
+    with pytest.raises(SessionException, match="already exists"):
+        repo.create_session(session)
+
+
+def test_delete_session_removes_row(pg_dsn: str) -> None:
+    _clean(pg_dsn)
+    repo = _repo(pg_dsn)
+    session = _session("sess-delete")
+    repo.create_session(session)
+    repo.delete_session("sess-delete")
+    assert repo.read_session("sess-delete") is None
+
+
+def test_delete_session_cascades_to_agents_and_messages(pg_dsn: str) -> None:
+    _clean(pg_dsn)
+    repo = _repo(pg_dsn)
+
+    sess = _session("sess-cascade")
+    repo.create_session(sess)
+    repo.create_agent("sess-cascade", _agent("a1"))
+    repo.create_message("sess-cascade", "a1", _message(0))
+
+    repo.delete_session("sess-cascade")
+
+    assert repo.read_session("sess-cascade") is None
+    assert repo.read_agent("sess-cascade", "a1") is None
+
+
+# ---------------------------------------------------------------------------
+# create_agent / read_agent / update_agent
+# ---------------------------------------------------------------------------
+
+
+def test_create_and_read_agent(pg_dsn: str) -> None:
+    _clean(pg_dsn)
+    repo = _repo(pg_dsn)
+
+    repo.create_session(_session("sess-agent"))
+    repo.create_agent("sess-agent", _agent("a1"))
+    result = repo.read_agent("sess-agent", "a1")
+
+    assert result is not None
+    assert result.agent_id == "a1"
+
+
+def test_read_agent_missing_returns_none(pg_dsn: str) -> None:
+    _clean(pg_dsn)
+    repo = _repo(pg_dsn)
+    repo.create_session(_session("sess-agent-missing"))
+    assert repo.read_agent("sess-agent-missing", "nonexistent") is None
+
+
+def test_create_agent_duplicate_raises(pg_dsn: str) -> None:
+    _clean(pg_dsn)
+    repo = _repo(pg_dsn)
+    repo.create_session(_session("sess-agent-dup"))
+    repo.create_agent("sess-agent-dup", _agent("a1"))
+
+    with pytest.raises(SessionException, match="already exists"):
+        repo.create_agent("sess-agent-dup", _agent("a1"))
+
+
+def test_update_agent_stores_new_state(pg_dsn: str) -> None:
+    _clean(pg_dsn)
+    repo = _repo(pg_dsn)
+
+    repo.create_session(_session("sess-update-agent"))
+    repo.create_agent("sess-update-agent", _agent("a1"))
+
+    updated = SessionAgent(
+        agent_id="a1",
+        state={"turn": 1},
+        conversation_manager_state={"__name__": "SlidingWindowConversationManager"},
+    )
+    repo.update_agent("sess-update-agent", updated)
+    result = repo.read_agent("sess-update-agent", "a1")
+
+    assert result is not None
+    assert result.state == {"turn": 1}
+
+
+def test_update_agent_nonexistent_raises(pg_dsn: str) -> None:
+    _clean(pg_dsn)
+    repo = _repo(pg_dsn)
+    repo.create_session(_session("sess-update-agent-missing"))
+
+    with pytest.raises(SessionException, match="does not exist"):
+        repo.update_agent("sess-update-agent-missing", _agent("ghost"))
+
+
+# ---------------------------------------------------------------------------
+# create_message / read_message / update_message / list_messages
+# ---------------------------------------------------------------------------
+
+
+def _setup_session_and_agent(repo: PostgresSessionRepository, session_id: str) -> None:
+    repo.create_session(Session(session_id=session_id, session_type=SessionType.AGENT))
+    repo.create_agent(session_id, _agent("a1"))
+
+
+def test_create_and_read_message(pg_dsn: str) -> None:
+    _clean(pg_dsn)
+    repo = _repo(pg_dsn)
+    _setup_session_and_agent(repo, "sess-msg")
+
+    repo.create_message("sess-msg", "a1", _message(0))
+    result = repo.read_message("sess-msg", "a1", 0)
+
+    assert result is not None
+    assert result.message_id == 0
+
+
+def test_read_message_missing_returns_none(pg_dsn: str) -> None:
+    _clean(pg_dsn)
+    repo = _repo(pg_dsn)
+    _setup_session_and_agent(repo, "sess-msg-missing")
+    assert repo.read_message("sess-msg-missing", "a1", 99) is None
+
+
+def test_create_message_idempotent_on_conflict(pg_dsn: str) -> None:
+    """ON CONFLICT DO NOTHING — second insert does not raise."""
+    _clean(pg_dsn)
+    repo = _repo(pg_dsn)
+    _setup_session_and_agent(repo, "sess-msg-idempotent")
+
+    msg = _message(0)
+    repo.create_message("sess-msg-idempotent", "a1", msg)
+    repo.create_message("sess-msg-idempotent", "a1", msg)  # must not raise
+
+    result = repo.read_message("sess-msg-idempotent", "a1", 0)
+    assert result is not None
+
+
+def test_update_message_stores_new_content(pg_dsn: str) -> None:
+    _clean(pg_dsn)
+    repo = _repo(pg_dsn)
+    _setup_session_and_agent(repo, "sess-msg-update")
+
+    repo.create_message("sess-msg-update", "a1", _message(0))
+
+    updated_msg = SessionMessage(
+        message={"role": "assistant", "content": [{"type": "text", "text": "reply"}]},
+        message_id=0,
+    )
+    repo.update_message("sess-msg-update", "a1", updated_msg)
+
+    result = repo.read_message("sess-msg-update", "a1", 0)
+    assert result is not None
+    assert result.message["role"] == "assistant"
+
+
+def test_update_message_nonexistent_raises(pg_dsn: str) -> None:
+    _clean(pg_dsn)
+    repo = _repo(pg_dsn)
+    _setup_session_and_agent(repo, "sess-msg-update-missing")
+
+    with pytest.raises(SessionException, match="does not exist"):
+        repo.update_message("sess-msg-update-missing", "a1", _message(99))
+
+
+def test_list_messages_ordered(pg_dsn: str) -> None:
+    _clean(pg_dsn)
+    repo = _repo(pg_dsn)
+    _setup_session_and_agent(repo, "sess-list-msgs")
+
+    for i in range(5):
+        msg = SessionMessage(
+            message={"role": "user", "content": [{"type": "text", "text": f"msg {i}"}]},
+            message_id=i,
+        )
+        repo.create_message("sess-list-msgs", "a1", msg)
+
+    results = repo.list_messages("sess-list-msgs", "a1")
+    assert [m.message_id for m in results] == list(range(5))
+
+
+def test_list_messages_with_limit_and_offset(pg_dsn: str) -> None:
+    _clean(pg_dsn)
+    repo = _repo(pg_dsn)
+    _setup_session_and_agent(repo, "sess-list-paged")
+
+    for i in range(6):
+        msg = SessionMessage(
+            message={"role": "user", "content": [{"type": "text", "text": f"msg {i}"}]},
+            message_id=i,
+        )
+        repo.create_message("sess-list-paged", "a1", msg)
+
+    page = repo.list_messages("sess-list-paged", "a1", limit=3, offset=2)
+    assert len(page) == 3
+    assert page[0].message_id == 2
+
+
+# ---------------------------------------------------------------------------
+# read_conversation_manager_name
+# ---------------------------------------------------------------------------
+
+
+def test_read_conversation_manager_name_present(pg_dsn: str) -> None:
+    _clean(pg_dsn)
+    repo = _repo(pg_dsn)
+
+    repo.create_session(_session("sess-cm"))
+    agent = SessionAgent(
+        agent_id="a1",
+        state={},
+        conversation_manager_state={"__name__": "SlidingWindowConversationManager"},
+    )
+    repo.create_agent("sess-cm", agent)
+
+    name = repo.read_conversation_manager_name("sess-cm")
+    assert name == "SlidingWindowConversationManager"
+
+
+def test_read_conversation_manager_name_no_session_returns_none(pg_dsn: str) -> None:
+    _clean(pg_dsn)
+    repo = _repo(pg_dsn)
+    assert repo.read_conversation_manager_name("sess-no-cm") is None
+
+
+# ---------------------------------------------------------------------------
+# session_lock — advisory lock round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_session_lock_acquires_and_releases(pg_dsn: str) -> None:
+    _clean(pg_dsn)
+    repo = _repo(pg_dsn)
+
+    with repo.session_lock("sess-lock"):
+        # While inside the context, we should be holding the advisory lock.
+        # Verify by trying a second connection that selects pg_advisory_lock with trylock.
+        with psycopg.connect(pg_dsn) as conn:
+            row = conn.execute(
+                "SELECT pg_try_advisory_lock(hashtext('strands:sess-lock')::bigint)"
+            ).fetchone()
+            # The lock is already held by the first connection; trylock should return false.
+            assert row is not None
+            lock_acquired = row[0]
+            assert lock_acquired is False
+
+
+def test_session_lock_released_after_context(pg_dsn: str) -> None:
+    _clean(pg_dsn)
+    repo = _repo(pg_dsn)
+
+    with repo.session_lock("sess-lock-release"):
+        pass
+
+    # After exiting the context, the lock should be released.
+    with psycopg.connect(pg_dsn) as conn:
+        row = conn.execute(
+            "SELECT pg_try_advisory_lock(hashtext('strands:sess-lock-release')::bigint)"
+        ).fetchone()
+        assert row is not None
+        assert row[0] is True
+        # Release the lock we just acquired in this connection.
+        conn.execute("SELECT pg_advisory_unlock(hashtext('strands:sess-lock-release')::bigint)")
+
+
+# ---------------------------------------------------------------------------
+# Concurrency — parallel creates do not corrupt state
+# ---------------------------------------------------------------------------
+
+
+def test_concurrent_session_creates_are_isolated(pg_dsn: str) -> None:
+    """Multiple threads writing distinct sessions must not interfere."""
+    _clean(pg_dsn)
+    errors: list[Exception] = []
+
+    def _write(idx: int) -> None:
+        try:
+            repo = _repo(pg_dsn)
+            sid = f"sess-concurrent-{idx}"
+            repo.create_session(Session(session_id=sid, session_type=SessionType.AGENT))
+            repo.create_agent(sid, _agent("a1"))
+            repo.create_message(sid, "a1", _message(0))
+        except Exception as exc:  # noqa: BLE001
+            errors.append(exc)
+
+    threads = [threading.Thread(target=_write, args=(i,)) for i in range(8)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert errors == [], f"concurrent writes produced errors: {errors}"
+
+    # Verify all sessions are readable
+    repo = _repo(pg_dsn)
+    for i in range(8):
+        assert repo.read_session(f"sess-concurrent-{i}") is not None

--- a/agent/uv.lock
+++ b/agent/uv.lock
@@ -508,6 +508,20 @@ wheels = [
 ]
 
 [[package]]
+name = "docker"
+version = "7.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "requests" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/91/9b/4a2ea29aeba62471211598dac5d96825bb49348fa07e906ea930394a83ce/docker-7.1.0.tar.gz", hash = "sha256:ad8c70e6e3f8926cb8a92619b832b4ea5299e2831c14284663184e200546fa6c", size = 117834, upload-time = "2024-05-23T11:13:57.216Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e3/26/57c6fb270950d476074c087527a558ccb6f4436657314bfb6cdf484114c4/docker-7.1.0-py3-none-any.whl", hash = "sha256:c96b93b7f0a746f9e77d325bcfb87422a3d8bd4f03136ae8a85b37f1898d5fc0", size = 147774, upload-time = "2024-05-23T11:13:55.01Z" },
+]
+
+[[package]]
 name = "docstring-parser"
 version = "0.18.0"
 source = { registry = "https://pypi.org/simple" }
@@ -872,6 +886,7 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "ruff" },
+    { name = "testcontainers" },
 ]
 
 [package.metadata]
@@ -888,6 +903,7 @@ requires-dist = [
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.13.0,<0.16.0" },
     { name = "strands-agents", extras = ["gemini", "openai", "anthropic"], specifier = ">=1.30.0,<2.0.0" },
     { name = "tenacity", specifier = ">=9.0.0,<10.0.0" },
+    { name = "testcontainers", extras = ["postgres"], marker = "extra == 'dev'", specifier = ">=4.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.34.2,<1.0.0" },
 ]
 provides-extras = ["dev"]
@@ -1943,6 +1959,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/47/c6/ee486fd809e357697ee8a44d3d69222b344920433d3b6666ccd9b374630c/tenacity-9.1.4.tar.gz", hash = "sha256:adb31d4c263f2bd041081ab33b498309a57c77f9acf2db65aadf0898179cf93a", size = 49413, upload-time = "2026-02-07T10:45:33.841Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d7/c1/eb8f9debc45d3b7918a32ab756658a0904732f75e555402972246b0b8e71/tenacity-9.1.4-py3-none-any.whl", hash = "sha256:6095a360c919085f28c6527de529e76a06ad89b23659fa881ae0649b867a9d55", size = 28926, upload-time = "2026-02-07T10:45:32.24Z" },
+]
+
+[[package]]
+name = "testcontainers"
+version = "4.14.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "docker" },
+    { name = "python-dotenv" },
+    { name = "typing-extensions" },
+    { name = "urllib3" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ca/ac/a597c3a0e02b26cbed6dd07df68be1e57684766fd1c381dee9b170a99690/testcontainers-4.14.2.tar.gz", hash = "sha256:1340ccf16fe3acd9389a6c9e1d9ab21d9fe99a8afdf8165f89c3e69c1967d239", size = 166841, upload-time = "2026-03-18T05:19:16.696Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/2d/26b8b30067d94339afee62c3edc9b803a6eb9332f521ba77d8aaab5de873/testcontainers-4.14.2-py3-none-any.whl", hash = "sha256:0d0522c3cd8f8d9627cda41f7a6b51b639fa57bdc492923c045117933c668d68", size = 125712, upload-time = "2026-03-18T05:19:15.29Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- `prometheus.py`: monkeypatch fake 24개 테스트, 20% → **100%**
- `k8s.py`: SDK 메서드 mock injection 56개 테스트, → **73%**
- `session_repository.py`: `testcontainers[postgresql]` + pgvector, 22개 테스트, 23% → **97%**
- agent TOTAL 58% → **70.88%**, CI 게이트 55% → 65%로 bump
- `tests/conftest.py`: Docker socket 자동 감지(Rancher Desktop / OrbStack / standard) + Ryuk 비활성화

## Test plan
- [x] `uv run ruff check app tests` 통과
- [x] `uv run pytest --cov=app --cov-fail-under=65` 303 passed, 70.88%
- [ ] CI 그린 확인

Refs #76