### PR TITLE
feat(chaos,charts,agent): HashMode redaction demo + align AI model defaults

### DIFF
--- a/agent/app/clients/llm_providers/base.py
+++ b/agent/app/clients/llm_providers/base.py
@@ -69,6 +69,6 @@ class StrandsModel(Protocol):
 # Default model IDs per provider
 DEFAULT_MODEL_IDS: dict[LLMProvider, str] = {
     LLMProvider.GEMINI: "gemini-3-flash-preview",
-    LLMProvider.OPENAI: "gpt-4o",
-    LLMProvider.ANTHROPIC: "claude-sonnet-4-20250514",
+    LLMProvider.OPENAI: "gpt-5.4-mini",
+    LLMProvider.ANTHROPIC: "claude-sonnet-4-6",
 }

--- a/chaos/Makefile
+++ b/chaos/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help incident oomkilled crashloop imagepull networkdelay 404 500 503 504 ratings-multi verify-clean clean-all lint
+.PHONY: help incident oomkilled crashloop imagepull networkdelay 404 500 503 504 ratings-multi redaction-demo verify-clean clean-all lint
 
 NAMESPACE ?= bookinfo
 NAMESPACES ?= bookinfo kube-rca
@@ -25,6 +25,12 @@ crashloop: ## Run CrashLoopBackOff scenario
 	WAIT_SECONDS="$(WAIT_SECONDS)" \
 	POLL_INTERVAL_SECONDS="$(POLL_INTERVAL_SECONDS)" \
 	./scripts/run-crashloop.sh
+
+redaction-demo: ## Run HashMode redaction demo (same JWT in 5 K8s spec locations, triggers CrashLoopBackOff)
+	@KUBE_CONTEXT="$(KUBE_CONTEXT)" \
+	WAIT_SECONDS="$(WAIT_SECONDS)" \
+	POLL_INTERVAL_SECONDS="$(POLL_INTERVAL_SECONDS)" \
+	./scripts/run-redaction-demo.sh
 
 imagepull: ## Run ImagePullBackOff scenario
 	@KUBE_CONTEXT="$(KUBE_CONTEXT)" \

--- a/chaos/scenarios/redaction-demo/target-deployment.yaml
+++ b/chaos/scenarios/redaction-demo/target-deployment.yaml
@@ -1,0 +1,82 @@
+# Demo scenario for HashMode (BUILTIN_REDACTION_HASH_MODE=true).
+#
+# A single fake JWT is placed in 5 distinct K8s spec locations. With
+# HashMode enabled the agent emits the same [HASH:xxxxxxxx] for every
+# occurrence (correlation preserved); with HashMode disabled all five
+# collapse to [MASKED] (correlation lost).
+#
+# Trigger: container echoes the token to stdout and exits 1 — produces
+# CrashLoopBackOff which fires KubePodCrashLooping → Alertmanager →
+# backend webhook → agent analysis → Slack/UI.
+#
+# Cleanup: `kubectl -n kube-rca delete -f` is invoked automatically by
+# scripts/run_scenario.sh on Enter / Ctrl-C.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: chaos-redaction-demo-config
+  namespace: kube-rca
+  labels:
+    app: chaos-redaction-demo-target
+data:
+  # Position #1: ConfigMap data key contains denylist substring "token".
+  api.token: |
+    eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJkZW1vIiwicm9sZSI6ImFkbWluIn0.fake-demo-signature-redaction-correlation
+  # Control value — should remain unmasked in agent output (proves masking
+  # is selective, not blanket).
+  region: ap-northeast-2
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: chaos-redaction-demo-target
+  namespace: kube-rca
+  labels:
+    app: chaos-redaction-demo-target
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: chaos-redaction-demo-target
+  template:
+    metadata:
+      labels:
+        app: chaos-redaction-demo-target
+      annotations:
+        # Position #2: annotation key contains denylist substring "token".
+        # demo.kuberca.io/ is not in _SAFE_ANNOTATION_PREFIXES so it is
+        # subject to standard key-denylist redaction.
+        demo.kuberca.io/api-token: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJkZW1vIiwicm9sZSI6ImFkbWluIn0.fake-demo-signature-redaction-correlation"
+    spec:
+      containers:
+        - name: app
+          image: busybox:1.36.1
+          env:
+            # Position #3: env name contains "token" → BuiltinRedactor
+            # _redact_env_list applies _mask_replacement to .value.
+            - name: DEMO_API_TOKEN
+              value: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJkZW1vIiwicm9sZSI6ImFkbWluIn0.fake-demo-signature-redaction-correlation"
+          envFrom:
+            - configMapRef:
+                name: chaos-redaction-demo-config
+          command: ["sh", "-c"]
+          # Position #4: args[0] embeds the raw JWT directly so the K8s
+          # API spec exposes the literal token (would be hidden if we only
+          # referenced $DEMO_API_TOKEN — env expansion happens at runtime
+          # inside the container, not in the spec).
+          # Position #5: the runtime echo prints the env-expanded JWT to
+          # stdout, where get_pod_logs picks it up.
+          args:
+            - >-
+              echo "Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJkZW1vIiwicm9sZSI6ImFkbWluIn0.fake-demo-signature-redaction-correlation";
+              echo "Boot with token: $DEMO_API_TOKEN";
+              sleep 3;
+              exit 1
+          resources:
+            requests:
+              cpu: "10m"
+              memory: "16Mi"
+            limits:
+              cpu: "50m"
+              memory: "32Mi"

--- a/chaos/scripts/run-redaction-demo.sh
+++ b/chaos/scripts/run-redaction-demo.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+exec "${SCRIPT_DIR}/run_scenario.sh" redaction-demo "$@"

--- a/chaos/scripts/run_scenario.sh
+++ b/chaos/scripts/run_scenario.sh
@@ -18,6 +18,7 @@ Scenarios:
   503           Istio fault injection: 503 Service Unavailable
   ratings-multi Combined ratings faults (404 from load-generator, 503 from reviews)
   504           Istio fault injection: 504 Gateway Timeout
+  redaction-demo Demo HashMode redaction (same JWT in 5 K8s spec locations)
 
 Environment:
   NAMESPACE              Target namespace (default: bookinfo)
@@ -194,6 +195,12 @@ case "$SCENARIO" in
   crashloop)
     TARGET_MANIFEST="${SCENARIOS_DIR}/crashloop/target-deployment.yaml"
     LABEL_SELECTOR="app=chaos-crashloop-target"
+    EXPECTED_REASON="CrashLoopBackOff"
+    DEFAULT_NAMESPACE="kube-rca"
+    ;;
+  redaction-demo)
+    TARGET_MANIFEST="${SCENARIOS_DIR}/redaction-demo/target-deployment.yaml"
+    LABEL_SELECTOR="app=chaos-redaction-demo-target"
     EXPECTED_REASON="CrashLoopBackOff"
     DEFAULT_NAMESPACE="kube-rca"
     ;;

--- a/charts/kube-rca/README.md
+++ b/charts/kube-rca/README.md
@@ -358,7 +358,7 @@ backend:
 | agent.masking.regexList | list | `[]` | Regex list (JSON array) for masking sensitive values before LLM requests and DB persistence. |
 | agent.nodeSelector | object | `{}` | Node labels for agent pods assignment. |
 | agent.openai.apiKey | string | `""` | OpenAI API key value. When set (and no existingSecret), chart creates the Secret. |
-| agent.openai.modelId | string | `"gpt-5-mini"` | OpenAI model ID for Strands Agents. |
+| agent.openai.modelId | string | `"gpt-5.4-mini"` | OpenAI model ID for Strands Agents. |
 | agent.openai.secret.create | bool | `false` | Create a Secret for the OpenAI API key. |
 | agent.openai.secret.existingSecret | string | `"kube-rca-ai"` | Existing Secret name for the OpenAI API key. |
 | agent.openai.secret.key | string | `"openai-api-key"` | Secret key name for the OpenAI API key. |

--- a/charts/kube-rca/kube-rca-eks-values.yaml
+++ b/charts/kube-rca/kube-rca-eks-values.yaml
@@ -95,7 +95,7 @@ agent:
   anthropic:
     modelId: "claude-sonnet-4-6"
   openai:
-    modelId: "gpt-5-mini"
+    modelId: "gpt-5.4-mini"
   sessionDB:
     host: kube-rca-postgresql.kube-rca.svc.cluster.local
     port: 5432

--- a/charts/kube-rca/kube-rca-values.yaml
+++ b/charts/kube-rca/kube-rca-values.yaml
@@ -92,12 +92,14 @@ agent:
     maxLogLines: 25
     maxEvents: 25
     summaryMaxItems: 3
+  masking:
+    builtinRedactionHashMode: true
   gemini:
     modelId: "gemini-3-flash-preview"
   anthropic:
     modelId: "claude-sonnet-4-6"
   openai:
-    modelId: "gpt-5-mini"
+    modelId: "gpt-5.4-mini"
   sessionDB:
     host: kube-rca-postgresql.kube-rca.svc.cluster.local
     port: 5432

--- a/charts/kube-rca/values.yaml
+++ b/charts/kube-rca/values.yaml
@@ -379,7 +379,7 @@ agent:
       key: "ai-studio-api-key"
   openai:
     # -- OpenAI model ID for Strands Agents.
-    modelId: "gpt-5-mini"
+    modelId: "gpt-5.4-mini"
     # -- OpenAI API key value. When set (and no existingSecret), chart creates the Secret.
     apiKey: ""
     secret:


### PR DESCRIPTION
## Summary

Adds the chaos scenario for the HashMode redaction demo and aligns AI model defaults across chart values, environment overrides, and agent code.

## Why

Preparing a demo that highlights why HashMode (`BUILTIN_REDACTION_HASH_MODE=true`) is valuable: with the default `[MASKED]` token the agent loses correlation between the same secret appearing in multiple K8s spec locations, while HashMode preserves it as a deterministic `[HASH:xxxxxxxx]`.

While at it, the OpenAI / Anthropic default model IDs were drifting between `charts/kube-rca/values.yaml`, the live override files, and `agent/app/clients/llm_providers/base.py`. This PR snaps them back into one consistent set.

## Changes

### 1. `feat(chaos)`: redaction-demo scenario (`17f429f`)

- New `chaos/scenarios/redaction-demo/target-deployment.yaml`: ConfigMap + Deployment with the same fake JWT in 5 K8s spec locations (env, args, annotation, configmap key, stdout log).
- `chaos/scripts/run-redaction-demo.sh` wrapper.
- `chaos/scripts/run_scenario.sh`: case block + usage doc.
- `chaos/Makefile`: `make redaction-demo` target.

CrashLoopBackOff trigger fires `KubePodCrashLooping` → Alertmanager → backend webhook → agent analysis. With HashMode on, the same `[HASH:xxxxxxxx]` appears in all 5 redacted spots in the agent output (correlation preserved).

### 2. `feat(charts)`: enable HashMode in kube-rca-values for demo (`342203e`)

- `agent.masking.builtinRedactionHashMode: true` (per-environment override; chart default stays `false`).
- `agent.openai.modelId`: `gpt-5-mini` → `gpt-5.4-mini`.

### 3. `chore(agent,charts)`: align AI model defaults (`adbeacb`)

- `charts/kube-rca/values.yaml`, `kube-rca-eks-values.yaml`, `README.md` openai modelId synced to `gpt-5.4-mini`.
- `agent/app/clients/llm_providers/base.py`:
  - `DEFAULT_MODEL_IDS[OPENAI]` `gpt-4o` → `gpt-5.4-mini`
  - `DEFAULT_MODEL_IDS[ANTHROPIC]` `claude-sonnet-4-20250514` → `claude-sonnet-4-6`

## Live behavior change

Only the HashMode toggle. Provider remains `gemini` and model remains `gemini-3-flash-preview` in the live ArgoCD environment, so OpenAI/Anthropic default updates are no-ops in production.

## Verification

- `helm dependency build && helm lint charts/kube-rca` — 0 failed
- `uv run ruff check app tests` — All checks passed
- `uv run pytest tests/test_llm_provider_factory.py tests/test_config.py tests/test_masking.py -q` — 34 passed
- `bash -n` + `shellcheck -x` on new/modified scripts — 0 issues
- `kubectl --dry-run=client apply -f scenarios/redaction-demo/target-deployment.yaml` — configmap + deployment created (dry run)

## Demo procedure (post-merge + ArgoCD sync)

1. Verify `kubectl -n kube-rca exec deploy/<agent> -- env | grep BUILTIN_REDACTION_HASH_MODE` → `true`.
2. `cd kuberca/main/chaos && make redaction-demo`.
3. Wait for `KubePodCrashLooping` → backend → agent analysis.
4. Confirm same `[HASH:xxxxxxxx]` repeats 5× in the analysis output (Slack thread or `/incidents` UI).
5. Toggle `builtinRedactionHashMode: false` for the contrast demonstration if desired.

## Out of scope

- `helm-docs` re-generation: README row was edited inline so the table stays consistent until the next helm-docs run.
- `testcontainers` dev-dep collection error in `uv run pytest` (full set) is pre-existing from commit `21fe00e` and not addressed here.
