### PR TITLE
fix(chaos): normalize JWT inputs in redaction-demo so 5 positions hash to same digest

### DIFF
--- a/chaos/scenarios/redaction-demo/target-deployment.yaml
+++ b/chaos/scenarios/redaction-demo/target-deployment.yaml
@@ -21,8 +21,10 @@ metadata:
     app: chaos-redaction-demo-target
 data:
   # Position #1: ConfigMap data key contains denylist substring "token".
-  api.token: |
-    eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJkZW1vIiwicm9sZSI6ImFkbWluIn0.fake-demo-signature-redaction-correlation
+  # Inline string (no `|` block scalar) so the value has no trailing
+  # newline — same input as the other positions, hashes to the same
+  # [HASH:xxxxxxxx].
+  api.token: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJkZW1vIiwicm9sZSI6ImFkbWluIn0.fake-demo-signature-redaction-correlation"
   # Control value — should remain unmasked in agent output (proves masking
   # is selective, not blanket).
   region: ap-northeast-2
@@ -61,18 +63,13 @@ spec:
             - configMapRef:
                 name: chaos-redaction-demo-config
           command: ["sh", "-c"]
-          # Position #4: args[0] embeds the raw JWT directly so the K8s
-          # API spec exposes the literal token (would be hidden if we only
-          # referenced $DEMO_API_TOKEN — env expansion happens at runtime
-          # inside the container, not in the spec).
-          # Position #5: the runtime echo prints the env-expanded JWT to
-          # stdout, where get_pod_logs picks it up.
+          # Position #4: args[0] embeds the raw JWT directly with no
+          # surrounding text. JWT regex matches the token substring and
+          # hashes exactly the raw JWT — same input as positions #1-3.
+          # Position #5: echo prints the same raw JWT to stdout, which
+          # get_pod_logs streams as a single log line.
           args:
-            - >-
-              echo "Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJkZW1vIiwicm9sZSI6ImFkbWluIn0.fake-demo-signature-redaction-correlation";
-              echo "Boot with token: $DEMO_API_TOKEN";
-              sleep 3;
-              exit 1
+            - 'echo eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJkZW1vIiwicm9sZSI6ImFkbWluIn0.fake-demo-signature-redaction-correlation; sleep 3; exit 1'
           resources:
             requests:
               cpu: "10m"


### PR DESCRIPTION
## Why

Live run on main produced **4 distinct `[HASH:xxxxxxxx]` values** across the 5 spec locations:
```
context_jsonb     | 5 occurrences, 4 distinct hashes
artifacts_result  | 2 occurrences, 1 distinct hash (c7b04b5a)
```
Two input shapes leaked through: ConfigMap value carried a trailing `\n` from yaml `|` block scalar, and args[0] wrapped the JWT inside an `echo "Authorization: Bearer ..."; echo "Boot with token: $DEMO_API_TOKEN";` script that the JWT regex matched against a different substring than the bare token.

## Changes

- ConfigMap `api.token`: `|` block scalar → inline `"..."` string. Removes trailing newline.
- args[0]: drop the `Authorization: Bearer` + `Boot with token: $DEMO_API_TOKEN` wrappers. Single `echo <raw-JWT>; sleep 3; exit 1`.

## Expected after merge

1-2 distinct hashes across positions #1-#5 (one of them the dominant raw-JWT hash repeated 5×). `kubectl.kubernetes.io/last-applied-configuration` annotation may add one extra occurrence with the same digest, which actually strengthens the correlation showcase.

## Verification

- `kubectl --dry-run=client apply -f scenarios/redaction-demo/target-deployment.yaml` — 0 errors.
- Post-merge: re-run `make redaction-demo`, then `psql` against `alert_analyses.context::text | grep -oE '\[HASH:[a-f0-9]{8}\]' | sort | uniq -c` should show one dominant hash with 5+ occurrences.