### PR TITLE
feat(frontend): make header logo clickable to navigate home

### DIFF
--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,3 +1,4 @@
+import { Link } from 'react-router-dom';
 import { LogOut, Sun, Moon, Globe } from 'lucide-react';
 import { languageLabels, useLanguage } from '../context/LanguageContext';
 import { useTheme } from '../context/ThemeContext';
@@ -13,13 +14,17 @@ export const Header: React.FC<HeaderProps> = ({ onLogout, connectionState }) => 
 
   return (
     <header className="fixed top-0 left-0 w-full h-14 bg-white dark:bg-slate-950 border-b border-slate-200 dark:border-slate-800 flex items-center px-5 z-50 transition-colors duration-300">
-      {/* Logo */}
-      <div className="flex items-center gap-2.5">
+      {/* Logo - clicking returns to home (Incident Dashboard) */}
+      <Link
+        to="/"
+        aria-label="Kube-RCA home"
+        className="flex items-center gap-2.5 rounded-md px-1 -mx-1 hover:opacity-80 focus:outline-none focus:ring-2 focus:ring-cyan-500/50 transition-opacity"
+      >
         <img src="/logo.png" alt="Kube-RCA" className="w-7 h-7" />
         <span className="text-base font-semibold font-mono tracking-wider text-slate-900 dark:text-slate-100">
           Kube-RCA
         </span>
-      </div>
+      </Link>
 
       {/* Right controls */}
       <div className="ml-auto flex items-center gap-3">


### PR DESCRIPTION
## What

Wrap the header logo and "Kube-RCA" title in a `react-router-dom` `<Link to="/">` so clicking the header returns the user to the Incident Dashboard from any view (detail pages, settings, analysis).

## Why

- Universal escape hatch from deep `/incidents/:id`, `/alerts/:id`, `/settings/*` views — equivalent to the Sidebar's first "Incidents" item but always visible (Header is `fixed top-0`).
- Standard UX pattern (GitHub, Linear, Notion) — meets user expectation that the top-left logo navigates home.

## How

- `<Link to="/">` instead of `<button onClick={navigate}>` to preserve native anchor behaviors:
  - ⌘/Ctrl + click → open in new tab
  - Right click → browser context menu
  - URL preview on hover
  - `<a>` semantic for assistive tech
- `hover:opacity-80` + `transition-opacity` for affordance
- `focus:ring-2 focus:ring-cyan-500/50` matching `Sidebar` active color so keyboard focus is consistent
- `aria-label="Kube-RCA home"` so screen readers do not read `<img alt>` + `<span>` text twice
- `-mx-1 px-1` so the focus ring gets visual padding without changing layout width

## Verification

- ✅ `npm run lint` (`--max-warnings 0`)
- ✅ `npm run build` (tsc + vite, 652 ms)
- Manual smoke (recommended after merge):
  - Click logo from `/incidents/:id` → routes to `/`
  - ⌘/Ctrl + click logo → opens `/` in new tab
  - `Tab` key → cyan focus ring appears around logo

## Scope

- `frontend/src/components/Header.tsx` (+8 / -3)
