### PR TITLE
fix(chaos): add make clean-redaction-demo for orphaned-resource cleanup

### DIFF
--- a/chaos/Makefile
+++ b/chaos/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help incident oomkilled crashloop imagepull networkdelay 404 500 503 504 ratings-multi redaction-demo verify-clean clean-all lint
+.PHONY: help incident oomkilled crashloop imagepull networkdelay 404 500 503 504 ratings-multi redaction-demo clean-redaction-demo verify-clean clean-all lint
 
 NAMESPACE ?= bookinfo
 NAMESPACES ?= bookinfo kube-rca
@@ -31,6 +31,9 @@ redaction-demo: ## Run HashMode redaction demo (same JWT in 5 K8s spec locations
 	WAIT_SECONDS="$(WAIT_SECONDS)" \
 	POLL_INTERVAL_SECONDS="$(POLL_INTERVAL_SECONDS)" \
 	./scripts/run-redaction-demo.sh
+
+clean-redaction-demo: ## Force-delete redaction-demo resources orphaned outside the script's trap-based cleanup (Pod/Deployment/ConfigMap)
+	@kubectl $(if $(KUBE_CONTEXT),--context $(KUBE_CONTEXT),) -n kube-rca delete -f scenarios/redaction-demo/target-deployment.yaml --ignore-not-found
 
 imagepull: ## Run ImagePullBackOff scenario
 	@KUBE_CONTEXT="$(KUBE_CONTEXT)" \


### PR DESCRIPTION
## Why

`run_scenario.sh`'s auto-cleanup relies on the script's EXIT trap, which fires only when the user presses Enter / Ctrl-C while the script is still attached to a live shell. If ssh disconnects or the demo is applied directly via kubectl outside the script, the `chaos-redaction-demo` Pod/Deployment/ConfigMap stay orphaned in CrashLoopBackOff indefinitely — Kubernetes has no native TTL field for Deployments.

Observed: a redaction-demo Deployment ran for 32 minutes with 11 restarts before it was manually noticed and cleaned up.

## Change

One-line make target plus PHONY entry. Pattern matches the existing `redaction-demo` target.

```make
clean-redaction-demo: ## Force-delete redaction-demo resources orphaned outside the script's trap-based cleanup (Pod/Deployment/ConfigMap)
	@kubectl $(if $(KUBE_CONTEXT),--context $(KUBE_CONTEXT),) -n kube-rca delete -f scenarios/redaction-demo/target-deployment.yaml --ignore-not-found
```

## Verification

- `make help` lists the new target.
- `kubectl --dry-run=client delete -f scenarios/redaction-demo/target-deployment.yaml` resolves both ConfigMap + Deployment.

## Out of scope

Other scenarios (oomkilled / crashloop / imagepull / 4xx / 5xx) share the same trap-based design and could each gain their own clean-* target later. Keeping this PR surgical to redaction-demo because that's the one with observed orphan.