### PR TITLE
fix(agent): redactor coverage for safe-prefix annotations and arbitrary args

### DIFF
--- a/agent/app/core/masking.py
+++ b/agent/app/core/masking.py
@@ -221,29 +221,54 @@ class BuiltinRedactor:
         return out
 
     def _redact_command_args(self, items: list[Any]) -> list[Any]:
-        """Redact sensitive flags like --password=xxx in command/args lists."""
+        """Redact sensitive flags and embedded secrets in command/args lists.
+
+        Two-pass redaction:
+          1. CLI-flag pattern (``--password=xxx``, ``--token=xxx``).
+          2. Value heuristics (JWT/Bearer/long base64) for secrets embedded
+             in shell scripts or arbitrary args strings, e.g.
+             ``sh -c 'echo eyJ...'``.
+        """
         out: list[Any] = []
         for item in items:
             if isinstance(item, str):
+                # 1. CLI-flag pattern.
                 redacted = _SENSITIVE_ARG_RE.sub(
                     lambda m: f"{m.group(1)}={_mask_replacement(self.hash_mode, m.group(3))}",
                     item,
                 )
+                # 2. Value heuristics — catch JWTs, Bearer tokens, base64
+                # blobs smuggled inside shell scripts or arbitrary args.
+                redacted = self._redact_text_value(redacted)
                 out.append(redacted)
             else:
                 out.append(self._redact_value(item))
         return out
 
     def _redact_annotations(self, annotations: dict[str, Any]) -> dict[str, Any]:
-        """Mask annotation values unless they have a known-safe prefix."""
+        """Mask annotation values with safe-prefix-aware policy.
+
+        Policy:
+          - Non-string values pass through unchanged.
+          - Keys NOT matching a safe prefix → whole value masked (annotation
+            key treated like a sensitive key).
+          - Keys matching a safe prefix (e.g. ``kubectl.kubernetes.io/``)
+            → still apply value heuristics (JWT/Bearer/base64). Catches
+            ``last-applied-configuration`` whose serialized spec may embed
+            user secrets, while preserving plain K8s metadata such as
+            ``app.kubernetes.io/version: "1.2.3"``.
+        """
         out: dict[str, Any] = {}
         for key, val in annotations.items():
-            if isinstance(val, str) and not any(
-                key.startswith(prefix) for prefix in _SAFE_ANNOTATION_PREFIXES
-            ):
-                out[key] = _mask_replacement(self.hash_mode, val)
-            else:
+            if not isinstance(val, str):
                 out[key] = val
+                continue
+            if any(key.startswith(prefix) for prefix in _SAFE_ANNOTATION_PREFIXES):
+                # Safe prefix: skip key-denylist whole-mask, but still scan
+                # the value for embedded secrets.
+                out[key] = self._redact_text_value(val, parent_key=key)
+            else:
+                out[key] = _mask_replacement(self.hash_mode, val)
         return out
 
     # -- Core traversal ------------------------------------------------------

--- a/agent/tests/test_masking.py
+++ b/agent/tests/test_masking.py
@@ -324,3 +324,73 @@ def test_builtin_redacts_nested_structures() -> None:
     annotations = result["spec"]["metadata"]["annotations"]
     assert annotations["custom.io/key"] == MASK_TOKEN
     assert annotations["kubernetes.io/name"] == "safe"
+
+
+# ---------------------------------------------------------------------------
+# Coverage: command/args list with embedded JWT (Leak 2 fix)
+# ---------------------------------------------------------------------------
+
+
+def test_command_args_redacts_embedded_jwt_in_shell_script() -> None:
+    """args list with raw JWT inside a shell script gets hashed by value heuristics.
+
+    Regression for the case where ``sh -c 'echo eyJ...; sleep 3; exit 1'`` was
+    leaking the raw JWT through ``_redact_command_args`` because the
+    ``--flag=value`` CLI pattern did not match it.
+    """
+    redactor = BuiltinRedactor(hash_mode=True)
+    jwt = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0In0.fake-signature"
+    pod_spec = {
+        "containers": [
+            {
+                "name": "app",
+                "command": ["sh", "-c"],
+                "args": [f"echo {jwt}; sleep 3; exit 1"],
+            }
+        ],
+    }
+    result = redactor.redact_object(pod_spec)
+    args_str = result["containers"][0]["args"][0]
+    assert jwt not in args_str
+    assert "[HASH:" in args_str
+
+
+# ---------------------------------------------------------------------------
+# Coverage: safe-prefix annotation with embedded secret (Leak 1 fix)
+# ---------------------------------------------------------------------------
+
+
+def test_kubectl_last_applied_configuration_redacts_embedded_jwt() -> None:
+    """kubectl.kubernetes.io/last-applied-configuration value is scanned for embedded JWT.
+
+    Regression for the case where the kubectl-managed annotation, whose
+    serialized spec carries user-data, was bypassed entirely under the
+    safe-prefix policy and leaked the raw token.
+    """
+    redactor = BuiltinRedactor(hash_mode=True)
+    jwt = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0In0.fake-signature"
+    metadata = {
+        "annotations": {
+            "kubectl.kubernetes.io/last-applied-configuration": (
+                f'{{"spec":{{"env":[{{"name":"X","value":"{jwt}"}}]}}}}'
+            ),
+        },
+    }
+    result = redactor.redact_object(metadata)
+    annotation_val = result["annotations"]["kubectl.kubernetes.io/last-applied-configuration"]
+    assert jwt not in annotation_val
+    assert "[HASH:" in annotation_val
+
+
+def test_safe_annotation_without_secret_passes_through() -> None:
+    """Plain K8s metadata annotation under safe prefix passes unchanged."""
+    redactor = BuiltinRedactor(hash_mode=True)
+    metadata = {
+        "annotations": {
+            "app.kubernetes.io/version": "1.2.3",
+            "app.kubernetes.io/name": "my-app",
+        },
+    }
+    result = redactor.redact_object(metadata)
+    assert result["annotations"]["app.kubernetes.io/version"] == "1.2.3"
+    assert result["annotations"]["app.kubernetes.io/name"] == "my-app"


### PR DESCRIPTION
## Why

Live demo evidence (PR #79 / #81 / #83 series) revealed two leak paths in `BuiltinRedactor` that exposed raw JWTs in agent → LLM messages even with `BUILTIN_REDACTION_HASH_MODE=true`:

1. **safe-prefix annotation bypass**: `_redact_annotations` skipped any annotation whose key started with a known-safe prefix (`kubectl.kubernetes.io/`, `app.kubernetes.io/`, …). The kubectl-managed `last-applied-configuration` annotation, whose value is a serialized spec carrying user data, leaked embedded tokens through this bypass.

2. **arbitrary-args leak**: `_redact_command_args` only matched the `--flag=value` CLI pattern, so `sh -c 'echo eyJ...; sleep 3; exit 1'` shell scripts in container args leaked the raw token verbatim.

Both surfaces showed up as raw JWT strings in `strands_messages.data` (agent ↔ LLM dialogue raw) for the chaos-redaction-demo target Deployment.

## Changes

`agent/app/core/masking.py`:

- **`_redact_annotations`**: safe-prefix policy now skips key-denylist whole-mask but still applies value heuristics (JWT / Bearer / long base64) so embedded user secrets are caught while plain K8s metadata (`app.kubernetes.io/version: "1.2.3"`) passes unchanged.
- **`_redact_command_args`**: two-pass redaction — CLI-flag pattern first (existing behavior), then value heuristics for secrets embedded in shell scripts or arbitrary args.

`agent/tests/test_masking.py`: adds 3 unit tests:

- `test_command_args_redacts_embedded_jwt_in_shell_script` — Leak 2 fix.
- `test_kubectl_last_applied_configuration_redacts_embedded_jwt` — Leak 1 fix.
- `test_safe_annotation_without_secret_passes_through` — regression for plain K8s metadata.

## Verification

```
$ uv run ruff check app tests
All checks passed!

$ uv run pytest tests/test_masking.py -v
26 passed in 0.03s
```

(Existing 23 tests green + 3 new = 26.)

## No-op for production today

KubeRCA's live agent runs with `AI_PROVIDER=gemini`, and the bypass paths affect any provider. After ArgoCD sync, the `strands_messages` raw dialogue should no longer contain raw JWTs from chaos-redaction-demo runs — distinct hash count for the demo token approaches 1, and `last-applied-configuration` annotation values become hashed substrings instead of raw JSON.