### PR TITLE
fix(agent/deps): bump python-multipart to 0.0.28 (CVE-2026-42561)

### DIFF
--- a/agent/uv.lock
+++ b/agent/uv.lock
@@ -866,7 +866,7 @@ wheels = [
 
 [[package]]
 name = "kube-rca-agent"
-version = "1.2.1"
+version = "1.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },
@@ -1579,11 +1579,11 @@ wheels = [
 
 [[package]]
 name = "python-multipart"
-version = "0.0.26"
+version = "0.0.28"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/88/71/b145a380824a960ebd60e1014256dbb7d2253f2316ff2d73dfd8928ec2c3/python_multipart-0.0.26.tar.gz", hash = "sha256:08fadc45918cd615e26846437f50c5d6d23304da32c341f289a617127b081f17", size = 43501, upload-time = "2026-04-10T14:09:59.473Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/54/a85eb421fbdd5007bc5af39d0f4ed9fa609e0fedbfdc2adcf0b34526870e/python_multipart-0.0.28.tar.gz", hash = "sha256:8550da197eac0f7ab748961fc9509b999fa2662ea25cef857f05249f6893c0f8", size = 45314, upload-time = "2026-05-10T11:05:16.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9a/22/f1925cdda983ab66fc8ec6ec8014b959262747e58bdca26a4e3d1da29d56/python_multipart-0.0.26-py3-none-any.whl", hash = "sha256:c0b169f8c4484c13b0dcf2ef0ec3a4adb255c4b7d18d8e420477d2b1dd03f185", size = 28847, upload-time = "2026-04-10T14:09:58.131Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/a2/43bbc5860b5034e2af4ef99a0e04d726ff329c43e192ef3abaa8d7ecfce5/python_multipart-0.0.28-py3-none-any.whl", hash = "sha256:10faac07eb966c3f48dc415f9dee46c04cb10d58d30a35677db8027c825ed9b6", size = 29438, upload-time = "2026-05-10T11:05:15.052Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Resolves Dependabot alert [#12](https://github.com/kube-rca/kuberca/security/dependabot/12)
(GHSA-pp6c-gr5w-3c5g, CVE-2026-42561) — **DoS via unbounded multipart
part headers** in `python-multipart < 0.0.27`. Used by FastAPI for
`multipart/form-data` parsing (transitive runtime dep through the
`fastapi` package).

## Changes

- `agent/uv.lock`: `python-multipart 0.0.26 → 0.0.28`
- `agent/uv.lock`: self version `kube-rca-agent 1.2.1 → 1.3.0`
  (incidental — the lock had drifted from `pyproject.toml::version`
  which was backfilled to 1.3.0 in #85)

## Verification

- `uv sync --all-extras` — clean install
- `uv run ruff check app tests` — clean
- `uv run pytest tests/test_config.py tests/test_analysis_service.py
  tests/test_llm_provider_factory.py` — **83 passed in 6.75s**

CI will run the full pytest + ruff suite.

## Closes

- Dependabot alert #12

## Note

After this PR merges, `release-please` PR #86 (1.3.1) will re-bump
the self version to 1.3.1; that's expected — the manifest is the
source of truth and lock will follow the same target string.
