### PR TITLE
chore(agent): tighten Tempo client type annotations

### DIFF
--- a/agent/app/clients/tempo.py
+++ b/agent/app/clients/tempo.py
@@ -220,22 +220,17 @@ def build_traceql_query(service_name: str | None, namespace: str | None) -> str:
 
 
 def _extract_trace_summaries(
-    payload: dict[str, object] | list[object],
+    payload: dict[str, object] | list[object] | None,
 ) -> list[dict[str, object]]:
-    entries: list[object]
+    entries: list[object] = []
     if isinstance(payload, dict):
-        if isinstance(payload.get("traces"), list):
-            entries = payload.get("traces", [])
-        elif isinstance(payload.get("data"), list):
-            entries = payload.get("data", [])
-        elif isinstance(payload.get("results"), list):
-            entries = payload.get("results", [])
-        else:
-            entries = []
+        for key in ("traces", "data", "results"):
+            value = payload.get(key)
+            if isinstance(value, list):
+                entries = value
+                break
     elif isinstance(payload, list):
         entries = payload
-    else:
-        entries = []
 
     normalized: list[dict[str, object]] = []
     for entry in entries:

--- a/agent/tests/test_tempo_client.py
+++ b/agent/tests/test_tempo_client.py
@@ -92,6 +92,27 @@ def test_build_traceql_query_empty() -> None:
     assert query == "{}"
 
 
+def test_extract_trace_summaries_returns_empty_for_none_payload() -> None:
+    # Caller (`search_traces`) returns early on error, but the function's type
+    # signature now accepts None to mirror the union from `_request_with_fallback`.
+    from app.clients.tempo import _extract_trace_summaries
+
+    assert _extract_trace_summaries(None) == []
+
+
+def test_extract_trace_summaries_falls_back_to_data_then_results() -> None:
+    # When `traces` key is missing, the function should walk `data` then
+    # `results` before giving up — preserves prior behavior across Tempo
+    # response shape variants.
+    from app.clients.tempo import _extract_trace_summaries
+
+    payload_data: dict[str, object] = {"data": [{"traceID": "abc"}]}
+    payload_results: dict[str, object] = {"results": [{"traceID": "def"}]}
+
+    assert [s["trace_id"] for s in _extract_trace_summaries(payload_data)] == ["abc"]
+    assert [s["trace_id"] for s in _extract_trace_summaries(payload_results)] == ["def"]
+
+
 def test_search_traces_preserves_unix_window(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("TEMPO_URL", "http://tempo.monitoring.svc.cluster.local:3200")
     captured = _install_fake_urlopen(monkeypatch)


### PR DESCRIPTION
## Summary

Followup to #88. Resolves the Pyright warnings preexisting in `agent/app/clients/tempo.py`:

- `[Line 77]` `_extract_trace_summaries(payload)` was called with a `dict | list | None` union but the function only accepted `dict | list`.
- `[Line 228/230/232]` Each branch assigned `payload.get(key, [])` (returns `object`) to `entries: list[object]`, which Pyright could not narrow.
- `[Line 238]` Trailing `else: entries = []` was unreachable given the declared `dict | list` type.

## Change

Widen the signature to `dict[str, object] | list[object] | None` and collapse the if/elif chain into a single isinstance-guarded `for` loop:

```python
entries: list[object] = []
if isinstance(payload, dict):
    for key in ("traces", "data", "results"):
        value = payload.get(key)
        if isinstance(value, list):
            entries = value
            break
elif isinstance(payload, list):
    entries = payload
```

- Pyright now narrows `value` to `list[object]` after `isinstance`, so `entries` assignment type-checks cleanly.
- The `else` branch is gone: `None` is now a legal input that yields `entries = []` via the initializer.

## No behavior change

- Callers (`search_traces`, `get_trace`) return early on `error is not None` before reaching `_extract_trace_summaries`, so a `None` payload was never passed at runtime.
- Non-dict / non-list payloads still produce an empty list, identical to before.
- Order of fallback keys (`traces` → `data` → `results`) preserved.

## Tests

- `test_extract_trace_summaries_returns_empty_for_none_payload` — encodes the new None contract explicitly.
- `test_extract_trace_summaries_falls_back_to_data_then_results` — locks in the dict-key fallback order that was previously implicit.
- All preexisting tests untouched.

## Verification

- `uv run pytest tests/test_tempo_client.py -v` → **10 passed** (8 from #88 + 2 new).
- `uv run pytest --ignore=tests/test_session_repository.py` → **288 passed in 14.37s**.
- `uv run ruff check app tests` → **All checks passed**.
