### PR TITLE
fix(ci): bump trivy-action to v0.36.0 in release-please workflow

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -122,7 +122,7 @@ jobs:
           push-to-registry: true
 
       - name: Trivy vulnerability scan
-        uses: aquasecurity/trivy-action@915b19bbe73b92a6cf82a1bc12b087c9a19a5fe2 # v0.28.0
+        uses: aquasecurity/trivy-action@a9c7b0f06e461e9d4b4d1711f154ee024b8d7ab8 # v0.36.0
         with:
           image-ref: ${{ steps.refs.outputs.ecr_image }}
           severity: CRITICAL,HIGH


### PR DESCRIPTION
## Summary

Fixes the publish-images matrix failure surfaced by PR #86 (1.3.1
release) where all 3 component publish jobs cancelled at `Set up job`:

```
##[error]Unable to resolve action `aquasecurity/setup-trivy@v0.2.1`,
unable to find version `v0.2.1`
```

`aquasecurity/trivy-action@v0.28.0` (currently pinned in
`release-please.yaml`) transitively references `setup-trivy@v0.2.1`,
which is not a published tag. `ci-backend.yaml` already runs cleanly
on `v0.36.0` (`a9c7b0f0…`) — bump `release-please.yaml` to the same
SHA so the next release publish (PR #90 / 1.3.2) succeeds end to end.

## Inventory

`grep -nE 'aquasecurity/(trivy-action|setup-trivy)' .github/workflows/*.yaml`
returns only this one stale reference:

```
.github/workflows/release-please.yaml:125:        uses: aquasecurity/trivy-action@915b19b... # v0.28.0
```

ci-backend.yaml is already fixed; ci-agent.yaml / ci-frontend.yaml /
ci-helm.yaml don't use trivy-action.

## Changes

- `.github/workflows/release-please.yaml` line 125:
  `trivy-action@915b19b... # v0.28.0` → `@a9c7b0f0... # v0.36.0`

## Verification

- `python3 yaml.safe_load(release-please.yaml)` — parses clean.
- Single-line action SHA bump, no other changes.
- The same SHA is already exercised in main via `ci-backend.yaml`.

## Impact

After merge, the next release-please tag publish (PR #90 / 1.3.2,
or any subsequent release) will run `publish-images` matrix without
the `setup-trivy` resolution error. ECR images for backend/agent/
frontend will publish in lockstep with the helm OCI chart.

## Out of scope

- Backfilling 1.3.1 ECR images that didn't publish (separate manual
  rebuild or wait for 1.3.2 release to supersede).
