### PR TITLE
feat!: add `language` config (ko|en) for analysis and Slack messages

### DIFF
--- a/agent/app/core/config.py
+++ b/agent/app/core/config.py
@@ -8,6 +8,23 @@ from dataclasses import dataclass
 DEFAULT_GEMINI_MODEL_ID = "gemini-3-flash-preview"
 DEFAULT_ANTHROPIC_MAX_TOKENS = 8192
 DEFAULT_AI_PROVIDER = "gemini"
+DEFAULT_LANGUAGE = "en"
+SUPPORTED_LANGUAGES = ("ko", "en")
+
+
+def normalize_language(value: str | None, default: str = DEFAULT_LANGUAGE) -> str:
+    """Normalize a language code to one of ``SUPPORTED_LANGUAGES``.
+
+    Falls back to ``default`` (which itself is normalized to ``en`` when
+    invalid) for unknown/empty values.
+    """
+    raw = (value or "").strip().lower()
+    if raw in SUPPORTED_LANGUAGES:
+        return raw
+    fallback = (default or "").strip().lower()
+    if fallback in SUPPORTED_LANGUAGES:
+        return fallback
+    return DEFAULT_LANGUAGE
 
 
 def _get_int_env(name: str, default: int) -> int:
@@ -82,6 +99,9 @@ def _validate_regex_list(patterns: list[str], name: str) -> None:
 class Settings:
     port: int
     log_level: str
+    # Default response language (ko | en). Used when a request does not
+    # provide its own ``language`` field.
+    language: str
     # AI Provider settings
     ai_provider: str  # gemini, openai, anthropic
     gemini_api_key: str
@@ -154,6 +174,7 @@ def load_settings() -> Settings:
     return Settings(
         port=_get_int_env("PORT", 8000),
         log_level=os.getenv("LOG_LEVEL", "info"),
+        language=normalize_language(os.getenv("LANGUAGE")),
         # AI Provider settings
         ai_provider=ai_provider,
         gemini_api_key=os.getenv("GEMINI_API_KEY", ""),

--- a/agent/app/core/dependencies.py
+++ b/agent/app/core/dependencies.py
@@ -108,9 +108,11 @@ def get_tempo_client() -> TempoClient | None:
 
 @lru_cache
 def get_chat_service() -> ChatService:
+    settings = get_settings()
     return ChatService(
         analysis_engine=get_analysis_engine(),
         masker=get_masker(),
+        default_language=settings.language,
     )
 
 
@@ -136,4 +138,5 @@ def get_analysis_service() -> AnalysisService:
         prompt_token_budget=settings.prompt_token_budget,
         prompt_max_log_lines=settings.prompt_max_log_lines,
         prompt_max_events=settings.prompt_max_events,
+        default_language=settings.language,
     )

--- a/agent/app/schemas/analysis.py
+++ b/agent/app/schemas/analysis.py
@@ -18,6 +18,7 @@ class AlertAnalysisRequest(BaseModel):
     incident_id: str | None = None
     analysis_type: str | None = None
     previous_analysis: PreviousAnalysisContext | None = None
+    language: str | None = None  # ko | en. None falls back to settings.language.
 
 
 class AlertAnalysisArtifact(BaseModel):
@@ -62,6 +63,7 @@ class IncidentSummaryRequest(BaseModel):
     fired_at: str
     resolved_at: str
     alerts: list[AlertSummaryInput]
+    language: str | None = None  # ko | en. None falls back to settings.language.
 
 
 class IncidentSummaryResponse(BaseModel):

--- a/agent/app/services/analysis.py
+++ b/agent/app/services/analysis.py
@@ -13,9 +13,55 @@ from app.clients.k8s import KubernetesClient, resolve_alert_target
 from app.clients.strands_agent import AnalysisEngine
 from app.clients.summary_store import SummaryStore
 from app.clients.tempo import TempoClient, build_traceql_query
+from app.core.config import DEFAULT_LANGUAGE, normalize_language
 from app.core.masking import Masker, RegexMasker
 from app.models.k8s import AnalysisTarget, K8sContext
 from app.schemas.analysis import AlertAnalysisRequest, IncidentSummaryRequest
+
+_KO_HEADERS: dict[str, str] = {
+    "root_cause": "근본 원인",
+    "evidence": "확인 근거",
+    "action_items": "조치 사항",
+    "missing_data": "누락된 데이터",
+    "recovery": "복구 확인",
+    "impact": "장애 영향",
+    "delta": "이전 분석 대비 변화",
+    "prevention": "재발 방지 권고",
+    "title": "제목",
+    "summary": "요약",
+    "detail": "상세 분석",
+    "incident_summary_sections": "근본 원인, 영향 범위, 해결 과정, 재발 방지 권고",
+}
+_EN_HEADERS: dict[str, str] = {
+    "root_cause": "Root Cause",
+    "evidence": "Evidence",
+    "action_items": "Action Items",
+    "missing_data": "Missing Data",
+    "recovery": "Recovery Confirmation",
+    "impact": "Impact Assessment",
+    "delta": "Delta Analysis",
+    "prevention": "Prevention Recommendations",
+    "title": "Title",
+    "summary": "Summary",
+    "detail": "Detail",
+    "incident_summary_sections": (
+        "root cause, impact scope, resolution timeline, prevention recommendations"
+    ),
+}
+
+
+def _headers(lang: str) -> dict[str, str]:
+    return _EN_HEADERS if lang == "en" else _KO_HEADERS
+
+
+def _resolve_request_language(value: str | None, default_language: str) -> str:
+    """Pick the response language for an analyze/summarize/chat request.
+
+    The request-level ``language`` field takes precedence; ``None``/invalid
+    values fall back to ``default_language`` (the service-level default,
+    typically derived from ``settings.language``).
+    """
+    return normalize_language(value, default=default_language)
 
 
 class AnalysisService:
@@ -36,6 +82,7 @@ class AnalysisService:
         prompt_token_budget: int = 32000,
         prompt_max_log_lines: int = 25,
         prompt_max_events: int = 25,
+        default_language: str = DEFAULT_LANGUAGE,
     ) -> None:
         self._logger = logging.getLogger(__name__)
         self._k8s_client = k8s_client
@@ -53,6 +100,7 @@ class AnalysisService:
         self._prompt_token_budget = max(0, prompt_token_budget)
         self._prompt_max_log_lines = max(0, prompt_max_log_lines)
         self._prompt_max_events = max(0, prompt_max_events)
+        self._default_language = normalize_language(default_language)
 
     def analyze(
         self, request: AlertAnalysisRequest
@@ -71,6 +119,7 @@ class AnalysisService:
         dict[str, object],
         list[dict[str, object]],
     ]:
+        lang = _resolve_request_language(request.language, self._default_language)
         t_start = time.perf_counter()
 
         target = resolve_alert_target(request.alert.labels)
@@ -133,10 +182,10 @@ class AnalysisService:
 
         if self._analysis_engine is None:
             analysis = self._masker.mask_text(
-                _fallback_summary(request, k8s_context, "analysis engine not configured")
+                _fallback_summary(request, k8s_context, "analysis engine not configured", lang)
             )
             analysis, summary, detail, summary_i18n, detail_i18n = _parse_alert_analysis_result(
-                analysis
+                analysis, lang
             )
             masked_context = build_masked_context(engine_issue="not_configured")
             return (
@@ -175,6 +224,7 @@ class AnalysisService:
             effective_max_log_lines,
             effective_max_events,
             self._masker,
+            lang,
         )
         t_prompt = time.perf_counter()
 
@@ -192,6 +242,7 @@ class AnalysisService:
                         request,
                         k8s_context,
                         "analysis engine returned empty response",
+                        lang,
                     )
                 )
                 (
@@ -200,7 +251,7 @@ class AnalysisService:
                     detail,
                     summary_i18n,
                     detail_i18n,
-                ) = _parse_alert_analysis_result(analysis)
+                ) = _parse_alert_analysis_result(analysis, lang)
                 masked_context = build_masked_context(engine_issue="empty_response")
                 self._log_analysis_timing(
                     t_start,
@@ -219,8 +270,8 @@ class AnalysisService:
                     masked_context,
                     masked_artifacts,
                 )
-            analysis, summary, detail, summary_i18n, detail_i18n = (
-                _parse_alert_analysis_result(analysis)
+            analysis, summary, detail, summary_i18n, detail_i18n = _parse_alert_analysis_result(
+                analysis, lang
             )
             self._store_summary(summary_key, summary)
             masked_context = build_masked_context()
@@ -251,10 +302,10 @@ class AnalysisService:
                 exc,
             )
             analysis = self._masker.mask_text(
-                _fallback_summary(request, k8s_context, error_cat.user_message)
+                _fallback_summary(request, k8s_context, error_cat.user_message, lang)
             )
             analysis, summary, detail, summary_i18n, detail_i18n = _parse_alert_analysis_result(
-                analysis
+                analysis, lang
             )
             masked_context = build_masked_context(engine_issue=error_cat.name)
             self._log_analysis_timing(
@@ -298,9 +349,7 @@ class AnalysisService:
             total_ms,
         )
 
-    def summarize_incident(
-        self, request: IncidentSummaryRequest
-    ) -> tuple[str, str, str]:
+    def summarize_incident(self, request: IncidentSummaryRequest) -> tuple[str, str, str]:
         title, summary, detail, _, _ = self.summarize_incident_with_i18n(request)
         return title, summary, detail
 
@@ -312,15 +361,17 @@ class AnalysisService:
         Returns:
             tuple[str, str, str]: (title, summary, detail)
         """
+        lang = _resolve_request_language(request.language, self._default_language)
         if self._analysis_engine is None:
             return self._mask_incident_result(
-                _fallback_incident_summary_result(request, "analysis engine not configured")
+                _fallback_incident_summary_result(request, "analysis engine not configured", lang)
             )
 
         prompt = _build_incident_summary_prompt(
             request,
             self._masker,
             self._prompt_token_budget,
+            lang,
         )
         try:
             session_id = _resolve_summary_session_id(request)
@@ -329,12 +380,12 @@ class AnalysisService:
                 result = ""
             masked_result = self._masker.mask_text(result)
             return self._mask_incident_result(
-                _parse_incident_summary_result(masked_result, request.title)
+                _parse_incident_summary_result(masked_result, request.title, lang)
             )
         except Exception as exc:  # noqa: BLE001
             self._logger.exception("Incident summary analysis failed")
             return self._mask_incident_result(
-                _fallback_incident_summary_result(request, f"analysis failed: {exc}")
+                _fallback_incident_summary_result(request, f"analysis failed: {exc}", lang)
             )
 
     def _mask_incident_result(
@@ -480,7 +531,15 @@ def _build_prompt(
     prompt_max_log_lines: int,
     prompt_max_events: int,
     masker: Masker,
+    lang: str = DEFAULT_LANGUAGE,
 ) -> str:
+    headers = _headers(lang)
+    primary_lang = "en" if lang == "en" else "ko"
+    language_focus = (
+        f"Render the primary response in {('English' if primary_lang == 'en' else 'Korean')}. "
+        f"Always emit both `ko` and `en` keys in the JSON envelope so the UI can switch "
+        f"languages, but write the bulk of your reasoning in the primary language first.\n"
+    )
     alert_payload = cast(
         dict[str, Any],
         masker.mask_object(request.alert.model_dump(by_alias=True, mode="json")),
@@ -535,10 +594,19 @@ def _build_prompt(
     )
     if analysis_type == "resolved" and request.previous_analysis is not None:
         prev = request.previous_analysis
+        resolved_sections = "\n".join(
+            f"- #### {headers[key]}" for key in ("recovery", "impact", "delta", "prevention")
+        )
+        action_example = (
+            "(e.g., 'Raise the memory limit to 512Mi.')"
+            if lang == "en"
+            else "(e.g., '메모리 limit을 512Mi로 상향 조정하십시오')"
+        )
         prompt = (
             "You are kube-rca-agent. This is a RESOLVED alert.\n"
             "Your goal is NOT to repeat the root cause analysis from the firing phase.\n"
             "Focus on recovery confirmation and post-incident insights.\n\n"
+            f"{language_focus}\n"
             "Return ONLY valid JSON with this exact shape:\n"
             "{\n"
             '  "ko": {"summary": "...", "detail": "..."},\n'
@@ -546,14 +614,12 @@ def _build_prompt(
             "}\n"
             "The `ko.detail` and `en.detail` values must be markdown strings.\n"
             "Resolved alert detail structure:\n"
-            "- #### 복구 확인 (Recovery Confirmation)\n"
-            "- #### 장애 영향 (Impact Assessment)\n"
-            "- #### 이전 분석 대비 변화 (Delta Analysis)\n"
-            "- #### 재발 방지 권고 (Prevention Recommendations)\n"
+            f"{resolved_sections}\n"
             "Formatting rules:\n"
             "- Use '####' for subsections.\n"
             "- Leave one blank line between sections/subsections.\n"
             "- Use '-' for unordered lists (do not use '*').\n"
+            f"- Action recommendations should be concrete {action_example}.\n"
             "- Limit each subsection to 3-5 bullets; one sentence per bullet (<= 120 chars).\n"
             "- Use inline code only for literal keys/values/commands.\n"
             f"{policy_block}"
@@ -564,9 +630,22 @@ def _build_prompt(
             f"Detail: {masker.mask_text(prev.detail)}\n\n"
         )
     else:
+        firing_section_names = ", ".join(
+            headers[key] for key in ("root_cause", "evidence", "action_items", "missing_data")
+        )
+        firing_section_headers = "\n".join(
+            f"  #### **{headers[key]}**"
+            for key in ("root_cause", "evidence", "action_items", "missing_data")
+        )
+        action_example = (
+            "(e.g., 'Raise the memory limit to 512Mi.')"
+            if lang == "en"
+            else "(e.g., '메모리 limit을 512Mi로 상향 조정하십시오')"
+        )
         prompt = (
             "You are kube-rca-agent. Analyze the alert using the provided Kubernetes context.\n"
             "Your audience is a human operator reading this on Slack.\n"
+            f"{language_focus}\n"
             "Return ONLY valid JSON with this exact shape:\n"
             "{\n"
             '  "ko": {"summary": "...", "detail": "..."},\n'
@@ -575,7 +654,7 @@ def _build_prompt(
             "`ko.summary` and `en.summary` should be 3-5 sentences "
             "including root cause, impact, and next action.\n"
             "`ko.detail` and `en.detail` must be markdown strings using "
-            "sections for 근본 원인, 확인 근거, 조치 사항, 누락된 데이터.\n"
+            f"sections for {firing_section_names}.\n"
             "\n"
             "Analysis behavior:\n"
             "- ACTIVELY use tools to discover information. "
@@ -584,10 +663,10 @@ def _build_prompt(
             "get_pod_status) to find the affected resources yourself.\n"
             "- Your analysis MUST contain completed findings based on evidence "
             "you gathered using tools.\n"
-            "- 조치 사항 must be actionable operator recommendations "
-            "(e.g., '메모리 limit을 512Mi로 상향 조정하십시오').\n"
-            "- 누락된 데이터 lists ONLY data you could NOT obtain even after using tools. "
-            "Do NOT list data that is expectedly absent "
+            f"- '{headers['action_items']}' must be actionable operator recommendations "
+            f"{action_example}.\n"
+            f"- '{headers['missing_data']}' lists ONLY data you could NOT obtain "
+            "even after using tools. Do NOT list data that is expectedly absent "
             "(e.g., previous_logs when restart_count is 0, "
             "or service info when no service label exists).\n"
             "- Prefer direct evidence from logs, events, workload state, "
@@ -597,10 +676,7 @@ def _build_prompt(
             "\n"
             "Formatting rules:\n"
             "- Each subsection MUST start with a bold '####' markdown header exactly as shown:\n"
-            "  #### **근본 원인**\n"
-            "  #### **확인 근거**\n"
-            "  #### **조치 사항**\n"
-            "  #### **누락된 데이터**\n"
+            f"{firing_section_headers}\n"
             "- Leave one blank line between sections/subsections.\n"
             "- Use '-' for unordered lists (do not use '*').\n"
             "- Limit each subsection to 3-5 bullets; one sentence per bullet (<= 120 chars).\n"
@@ -1228,7 +1304,13 @@ def _fallback_summary(
     request: AlertAnalysisRequest,
     k8s_context: K8sContext,
     reason: str,
+    lang: str = DEFAULT_LANGUAGE,
 ) -> str:
+    # ``lang`` is reserved for callers that want a localized header line.
+    # Today the fallback body stays in English (operator-facing diagnostic text);
+    # downstream ``_parse_alert_analysis_result`` clones the same text into the
+    # i18n dicts so the UI still receives both keys.
+    del lang
     alert = request.alert
     lines = [
         f"analysis engine unavailable: {reason}",
@@ -1264,22 +1346,38 @@ def _to_pretty_json(payload: dict[str, Any]) -> str:
 
 
 def _fallback_incident_summary_result(
-    request: IncidentSummaryRequest, reason: str
+    request: IncidentSummaryRequest,
+    reason: str,
+    lang: str = DEFAULT_LANGUAGE,
 ) -> tuple[str, str, str, dict[str, str], dict[str, str]]:
     """Generate fallback summary when analysis engine is unavailable."""
     alert_names = [a.alert_name for a in request.alerts]
     title = request.title  # Keep original title
-    summary = f"인시던트 분석 불가: {reason}"
-    detail_lines = [
-        f"인시던트 ID: {request.incident_id}",
-        f"제목: {request.title}",
-        f"심각도: {request.severity}",
-        f"발생 시각: {request.fired_at}",
-        f"해결 시각: {request.resolved_at}",
-        f"관련 알림 ({len(request.alerts)}개): {', '.join(alert_names)}",
-        "",
-        f"분석 엔진 오류: {reason}",
-    ]
+
+    if lang == "en":
+        summary = f"Incident analysis unavailable: {reason}"
+        detail_lines = [
+            f"Incident ID: {request.incident_id}",
+            f"Title: {request.title}",
+            f"Severity: {request.severity}",
+            f"Fired at: {request.fired_at}",
+            f"Resolved at: {request.resolved_at}",
+            f"Related alerts ({len(request.alerts)}): {', '.join(alert_names)}",
+            "",
+            f"Analysis engine error: {reason}",
+        ]
+    else:
+        summary = f"인시던트 분석 불가: {reason}"
+        detail_lines = [
+            f"인시던트 ID: {request.incident_id}",
+            f"제목: {request.title}",
+            f"심각도: {request.severity}",
+            f"발생 시각: {request.fired_at}",
+            f"해결 시각: {request.resolved_at}",
+            f"관련 알림 ({len(request.alerts)}개): {', '.join(alert_names)}",
+            "",
+            f"분석 엔진 오류: {reason}",
+        ]
     detail = "\n".join(detail_lines)
     summary_i18n = {"ko": summary, "en": summary}
     detail_i18n = {"ko": detail, "en": detail}
@@ -1323,23 +1421,34 @@ def _extract_inline_value(text: str, keys: list[str]) -> str:
     return ""
 
 
-def _parse_incident_summary(result: str, original_title: str) -> tuple[str, str, str]:
+def _parse_incident_summary(
+    result: str,
+    original_title: str,
+    lang: str = DEFAULT_LANGUAGE,
+) -> tuple[str, str, str]:
     """Parse AI response into title, summary and detail.
 
-    The AI is instructed to return structured content with 제목, 요약 and 상세 분석 sections.
-    Tries markdown-header extraction first, then inline colon-based extraction.
+    The AI is instructed to return structured content with 제목/Title, 요약/Summary
+    and 상세 분석/Detail sections. Tries markdown-header extraction first, then
+    inline colon-based extraction. ``lang`` only reorders the key preference list
+    so the matching language wins ties; both languages are still recognized.
     """
     all_keys = ["제목", "title", "요약", "summary", "상세", "detail"]
+    title_keys = ["title", "제목"] if lang == "en" else ["제목", "title"]
+    summary_keys = ["summary", "요약"] if lang == "en" else ["요약", "summary"]
+    detail_keys = (
+        ["detail", "상세 분석", "상세"] if lang == "en" else ["상세 분석", "상세", "detail"]
+    )
 
     # 1) Markdown header format (### 제목\ncontent)
-    title = _extract_section(result, ["제목", "title"], all_keys) or ""
-    summary = _extract_section(result, ["요약", "summary"], all_keys) or ""
+    title = _extract_section(result, title_keys, all_keys) or ""
+    summary = _extract_section(result, summary_keys, all_keys) or ""
 
     # 2) Inline format (**제목 (Title)**: content)
     if not title:
-        title = _extract_inline_value(result, ["제목", "title"])
+        title = _extract_inline_value(result, title_keys)
     if not summary:
-        summary = _extract_inline_value(result, ["요약", "summary"])
+        summary = _extract_inline_value(result, summary_keys)
 
     # Title should be first line only
     if title:
@@ -1362,7 +1471,7 @@ def _parse_incident_summary(result: str, original_title: str) -> tuple[str, str,
         title = title[:_TITLE_MAX_LEN].rstrip() + "…"
 
     # Extract only the detail section; fall back to full result if not found.
-    detail = _extract_section(result, ["상세 분석", "상세", "detail"], all_keys) or result
+    detail = _extract_section(result, detail_keys, all_keys) or result
     return title, summary, detail
 
 
@@ -1390,15 +1499,17 @@ def _normalize_i18n_texts(
     return {"ko": ko_text, "en": en_text}, ko_text, en_text
 
 
-def _compose_alert_analysis(summary: str, detail: str) -> str:
+def _compose_alert_analysis(summary: str, detail: str, lang: str = DEFAULT_LANGUAGE) -> str:
+    headers = _headers(lang)
     return (
-        f"### 1) 요약 (Summary)\n{summary.strip()}\n\n"
-        f"### 2) 상세 분석 (Detail)\n{detail.strip()}"
+        f"### 1) {headers['summary']}\n{summary.strip()}\n\n"
+        f"### 2) {headers['detail']}\n{detail.strip()}"
     ).strip()
 
 
 def _parse_alert_analysis_result(
     result: str,
+    lang: str = DEFAULT_LANGUAGE,
 ) -> tuple[str, str, str, dict[str, str], dict[str, str]]:
     payload = _parse_bilingual_payload(result)
     if payload is not None:
@@ -1408,36 +1519,42 @@ def _parse_alert_analysis_result(
         ko_detail = str(ko.get("detail", "")).strip()
         en_summary = str(en.get("summary", "")).strip()
         en_detail = str(en.get("detail", "")).strip()
-        summary_i18n, ko_summary, _ = _normalize_i18n_texts(ko_summary, en_summary)
-        detail_i18n, ko_detail, _ = _normalize_i18n_texts(ko_detail, en_detail)
-        analysis = _compose_alert_analysis(ko_summary, ko_detail)
-        return analysis, ko_summary, ko_detail, summary_i18n, detail_i18n
+        summary_i18n, ko_summary, en_summary = _normalize_i18n_texts(ko_summary, en_summary)
+        detail_i18n, ko_detail, en_detail = _normalize_i18n_texts(ko_detail, en_detail)
+        primary_summary = en_summary if lang == "en" else ko_summary
+        primary_detail = en_detail if lang == "en" else ko_detail
+        analysis = _compose_alert_analysis(primary_summary, primary_detail, lang)
+        return analysis, primary_summary, primary_detail, summary_i18n, detail_i18n
 
-    summary, detail = _split_alert_analysis(result)
+    summary, detail = _split_alert_analysis(result, lang)
     summary_i18n = {"ko": summary, "en": summary}
     detail_i18n = {"ko": detail, "en": detail}
     return result, summary, detail, summary_i18n, detail_i18n
 
 
 def _parse_incident_summary_result(
-    result: str, original_title: str
+    result: str,
+    original_title: str,
+    lang: str = DEFAULT_LANGUAGE,
 ) -> tuple[str, str, str, dict[str, str], dict[str, str]]:
     payload = _parse_bilingual_payload(result)
     if payload is not None:
         title = str(payload.get("title", "")).strip() or original_title
         ko = payload.get("ko") if isinstance(payload.get("ko"), dict) else {}
         en = payload.get("en") if isinstance(payload.get("en"), dict) else {}
-        summary_i18n, ko_summary, _ = _normalize_i18n_texts(
+        summary_i18n, ko_summary, en_summary = _normalize_i18n_texts(
             str(ko.get("summary", "")).strip(),
             str(en.get("summary", "")).strip(),
         )
-        detail_i18n, ko_detail, _ = _normalize_i18n_texts(
+        detail_i18n, ko_detail, en_detail = _normalize_i18n_texts(
             str(ko.get("detail", "")).strip(),
             str(en.get("detail", "")).strip(),
         )
-        return title, ko_summary, ko_detail, summary_i18n, detail_i18n
+        primary_summary = en_summary if lang == "en" else ko_summary
+        primary_detail = en_detail if lang == "en" else ko_detail
+        return title, primary_summary, primary_detail, summary_i18n, detail_i18n
 
-    title, summary, detail = _parse_incident_summary(result, original_title)
+    title, summary, detail = _parse_incident_summary(result, original_title, lang)
     summary_i18n = {"ko": summary, "en": summary}
     detail_i18n = {"ko": detail, "en": detail}
     return title, summary, detail, summary_i18n, detail_i18n
@@ -1626,13 +1743,22 @@ def _build_incident_summary_prompt(
     request: IncidentSummaryRequest,
     masker: Masker,
     prompt_token_budget: int,
+    lang: str = DEFAULT_LANGUAGE,
 ) -> str:
     incident_data = _build_incident_summary_payload(request)
     incident_data = cast(dict[str, Any], masker.mask_object(incident_data))
 
+    headers = _headers(lang)
+    primary_language_label = "English" if lang == "en" else "Korean"
+    language_focus = (
+        f"Write the primary narrative in {primary_language_label}, "
+        f"but always populate both `ko` and `en` so the UI can switch languages.\n"
+    )
+
     prompt_prefix = (
         "You are kube-rca-agent. An incident has been resolved and you need to "
         "provide a final RCA summary.\n"
+        f"{language_focus}"
         "Analyze ALL alerts and their individual analyses to synthesize a "
         "comprehensive incident summary. Every distinct alert type "
         "(e.g. 5xx errors AND 4xx errors) must be addressed in the summary "
@@ -1651,15 +1777,19 @@ def _build_incident_summary_prompt(
         "- `ko.summary` and `en.summary` should be 1-2 sentences "
         "describing the root cause and resolution.\n"
         "- `ko.detail` and `en.detail` must be markdown strings covering "
-        "근본 원인, 영향 범위, 해결 과정, 재발 방지 권고.\n\n"
+        f"{headers['incident_summary_sections']}.\n\n"
     )
     return _apply_incident_summary_budget(prompt_prefix, incident_data, prompt_token_budget)
 
 
-def _split_alert_analysis(result: str) -> tuple[str, str]:
+def _split_alert_analysis(result: str, lang: str = DEFAULT_LANGUAGE) -> tuple[str, str]:
     all_keys = ["요약", "summary", "상세", "detail"]
-    summary = _extract_section(result, ["요약", "summary"], all_keys)
-    detail = _extract_section(result, ["상세 분석", "상세", "detail"], all_keys)
+    summary_keys = ["summary", "요약"] if lang == "en" else ["요약", "summary"]
+    detail_keys = (
+        ["detail", "상세 분석", "상세"] if lang == "en" else ["상세 분석", "상세", "detail"]
+    )
+    summary = _extract_section(result, summary_keys, all_keys)
+    detail = _extract_section(result, detail_keys, all_keys)
 
     if not detail:
         detail = result.strip()

--- a/agent/app/services/chat.py
+++ b/agent/app/services/chat.py
@@ -5,6 +5,7 @@ import logging
 from typing import Any, cast
 
 from app.clients.strands_agent import AnalysisEngine
+from app.core.config import DEFAULT_LANGUAGE, normalize_language
 from app.core.masking import Masker, RegexMasker
 from app.schemas.chat import ChatRequest
 
@@ -23,9 +24,10 @@ def _is_invalid_session_restore_error(exc: BaseException) -> bool:
         if marker in visited:
             continue
         visited.add(marker)
-        if isinstance(current, ValueError) and "invalid conversation manager state" in str(
-            current
-        ).lower():
+        if (
+            isinstance(current, ValueError)
+            and "invalid conversation manager state" in str(current).lower()
+        ):
             return True
         stack.append(getattr(current, "__cause__", None))
         stack.append(getattr(current, "__context__", None))
@@ -37,10 +39,14 @@ def _to_pretty_json(payload: dict[str, Any]) -> str:
     return json.dumps(payload, ensure_ascii=True, indent=2, sort_keys=True)
 
 
-def _build_chat_prompt(request: ChatRequest, masker: Masker) -> str:
+def _build_chat_prompt(
+    request: ChatRequest,
+    masker: Masker,
+    default_language: str = DEFAULT_LANGUAGE,
+) -> str:
     """Build prompt for chat Q&A about an incident."""
     user_msg = masker.mask_text(request.message).strip() or "Tell me about this incident."
-    language = "en" if (request.language or "").strip().lower() == "en" else "ko"
+    language = normalize_language(request.language, default=default_language)
     response_language = "English" if language == "en" else "Korean"
     base = (
         "You are kube-rca-agent. A user is asking a question about an incident. "
@@ -66,10 +72,12 @@ class ChatService:
         self,
         analysis_engine: AnalysisEngine | None,
         masker: Masker | None = None,
+        default_language: str = DEFAULT_LANGUAGE,
     ) -> None:
         self._logger = logger
         self._analysis_engine = analysis_engine
         self._masker = masker or RegexMasker()
+        self._default_language = normalize_language(default_language)
 
     def chat(self, request: ChatRequest) -> tuple[str, str | None]:
         """Answer user questions about an incident (name, id, content, metrics, etc.).
@@ -84,7 +92,7 @@ class ChatService:
                 ),
                 request.conversation_id,
             )
-        prompt = _build_chat_prompt(request, self._masker)
+        prompt = _build_chat_prompt(request, self._masker, self._default_language)
         session_id = (request.conversation_id or "default").strip() or "default"
         session_id = f"{session_id}:chat"
         try:

--- a/agent/tests/test_analysis_service.py
+++ b/agent/tests/test_analysis_service.py
@@ -1549,3 +1549,316 @@ def test_analysis_service_error_categorization_integration() -> None:
     assert "analysis engine unavailable" in analysis
     assert "RuntimeError" in analysis
     assert ctx.get("analysis_quality") == "low"
+
+
+# ── language / i18n ────────────────────────────────────────────────────────
+
+
+def _empty_context() -> K8sContext:
+    return K8sContext(
+        namespace="default",
+        pod_name="demo-pod",
+        workload=None,
+        pod_status=None,
+        events=[],
+        previous_logs=[],
+        warnings=[],
+    )
+
+
+def _ko_request() -> AlertAnalysisRequest:
+    return AlertAnalysisRequest(
+        alert=Alert(
+            status="firing",
+            labels={"namespace": "default", "pod": "demo-pod"},
+            annotations={"summary": "Test"},
+            fingerprint="lang-ko",
+        ),
+        thread_ts="1234567890.123456",
+        language="ko",
+    )
+
+
+def _en_request() -> AlertAnalysisRequest:
+    return AlertAnalysisRequest(
+        alert=Alert(
+            status="firing",
+            labels={"namespace": "default", "pod": "demo-pod"},
+            annotations={"summary": "Test"},
+            fingerprint="lang-en",
+        ),
+        thread_ts="1234567890.123456",
+        language="en",
+    )
+
+
+def test_analysis_prompt_korean_uses_korean_section_headers() -> None:
+    engine = CapturingAnalysisEngine("ok")
+    service = AnalysisService(
+        FakeKubernetesClient(_empty_context()),
+        analysis_engine=engine,
+        default_language="en",  # ensure request override beats service default
+    )
+
+    service.analyze(_ko_request())
+
+    assert "근본 원인" in engine.last_prompt
+    assert "확인 근거" in engine.last_prompt
+    assert "조치 사항" in engine.last_prompt
+    assert "누락된 데이터" in engine.last_prompt
+    # English mirror headers should not leak into the Korean prompt body
+    assert "#### **Root Cause**" not in engine.last_prompt
+    assert "#### **Action Items**" not in engine.last_prompt
+
+
+def test_analysis_prompt_english_uses_english_section_headers() -> None:
+    engine = CapturingAnalysisEngine("ok")
+    service = AnalysisService(
+        FakeKubernetesClient(_empty_context()),
+        analysis_engine=engine,
+        default_language="ko",  # ensure request override beats service default
+    )
+
+    service.analyze(_en_request())
+
+    assert "Root Cause" in engine.last_prompt
+    assert "Evidence" in engine.last_prompt
+    assert "Action Items" in engine.last_prompt
+    assert "Missing Data" in engine.last_prompt
+    assert "#### **근본 원인**" not in engine.last_prompt
+    assert "#### **조치 사항**" not in engine.last_prompt
+
+
+def test_analysis_language_fallback_to_default_when_request_missing() -> None:
+    engine = CapturingAnalysisEngine("ok")
+    service = AnalysisService(
+        FakeKubernetesClient(_empty_context()),
+        analysis_engine=engine,
+        default_language="en",
+    )
+
+    service.analyze(_sample_request())  # language=None -> settings default ("en")
+
+    assert "Root Cause" in engine.last_prompt
+    assert "#### **근본 원인**" not in engine.last_prompt
+
+
+def test_analysis_language_invalid_falls_back_to_default() -> None:
+    engine = CapturingAnalysisEngine("ok")
+    service = AnalysisService(
+        FakeKubernetesClient(_empty_context()),
+        analysis_engine=engine,
+        default_language="ko",
+    )
+    request = AlertAnalysisRequest(
+        alert=Alert(
+            status="firing",
+            labels={"namespace": "default", "pod": "demo-pod"},
+            annotations={"summary": "Test"},
+            fingerprint="lang-bogus",
+        ),
+        thread_ts="1234567890.123456",
+        language="fr",  # unsupported
+    )
+
+    service.analyze(request)
+
+    assert "근본 원인" in engine.last_prompt
+    assert "#### **Root Cause**" not in engine.last_prompt
+
+
+def test_analysis_extracts_english_response_sections() -> None:
+    """English LLM markdown response is parsed into summary/detail via _split_alert_analysis."""
+    response_text = (
+        "### Summary\n"
+        "Pod restarted due to OOMKill.\n\n"
+        "### Detail\n"
+        "#### Root Cause\n"
+        "- memory exceeded limit\n"
+        "#### Evidence\n"
+        "- event: OOMKilled\n"
+    )
+    engine = FakeAnalysisEngine(response_text)
+    service = AnalysisService(
+        FakeKubernetesClient(_empty_context()),
+        analysis_engine=engine,
+        default_language="en",
+    )
+
+    analysis, summary, detail, ctx, _ = service.analyze(_en_request())
+
+    assert "Pod restarted due to OOMKill." in summary
+    assert "Root Cause" in detail
+    # Non-bilingual response: raw markdown is preserved as the analysis string.
+    assert "### Summary" in analysis
+    assert "### Detail" in analysis
+    assert ctx.get("analysis_quality")
+
+
+def test_incident_summary_prompt_korean_sections() -> None:
+    engine = CapturingAnalysisEngine("ok")
+    service = AnalysisService(
+        FakeKubernetesClient(_empty_context()),
+        analysis_engine=engine,
+        default_language="en",
+    )
+    request = IncidentSummaryRequest(
+        incident_id="inc-1",
+        title="bookinfo outage",
+        severity="critical",
+        fired_at="2024-01-01T12:00:00Z",
+        resolved_at="2024-01-01T12:10:00Z",
+        alerts=[
+            AlertSummaryInput(
+                fingerprint="fp-1",
+                alert_name="HighErrorRate",
+                severity="critical",
+                status="firing",
+            )
+        ],
+        language="ko",
+    )
+
+    service.summarize_incident_with_i18n(request)
+
+    assert "근본 원인" in engine.last_prompt
+    assert "재발 방지 권고" in engine.last_prompt
+
+
+def test_incident_summary_prompt_english_sections() -> None:
+    engine = CapturingAnalysisEngine("ok")
+    service = AnalysisService(
+        FakeKubernetesClient(_empty_context()),
+        analysis_engine=engine,
+        default_language="ko",
+    )
+    request = IncidentSummaryRequest(
+        incident_id="inc-2",
+        title="bookinfo outage",
+        severity="critical",
+        fired_at="2024-01-01T12:00:00Z",
+        resolved_at="2024-01-01T12:10:00Z",
+        alerts=[
+            AlertSummaryInput(
+                fingerprint="fp-2",
+                alert_name="HighErrorRate",
+                severity="critical",
+                status="firing",
+            )
+        ],
+        language="en",
+    )
+
+    service.summarize_incident_with_i18n(request)
+
+    assert "root cause" in engine.last_prompt
+    assert "prevention recommendations" in engine.last_prompt
+
+
+def test_incident_summary_fallback_localized_to_english() -> None:
+    service = AnalysisService(
+        FakeKubernetesClient(_empty_context()),
+        analysis_engine=None,
+        default_language="en",
+    )
+    request = IncidentSummaryRequest(
+        incident_id="inc-3",
+        title="bookinfo outage",
+        severity="critical",
+        fired_at="2024-01-01T12:00:00Z",
+        resolved_at="2024-01-01T12:10:00Z",
+        alerts=[
+            AlertSummaryInput(
+                fingerprint="fp-3",
+                alert_name="HighErrorRate",
+                severity="critical",
+                status="firing",
+            )
+        ],
+        language="en",
+    )
+
+    _, summary, detail, _, _ = service.summarize_incident_with_i18n(request)
+
+    assert "Incident analysis unavailable" in summary
+    assert "Incident ID" in detail
+    assert "인시던트" not in summary
+    assert "인시던트" not in detail
+
+
+def test_parse_alert_analysis_result_prefers_request_language() -> None:
+    """Bilingual JSON response should expose the requested language as primary."""
+    from app.services.analysis import _parse_alert_analysis_result
+
+    bilingual = json.dumps(
+        {
+            "ko": {"summary": "요약-한국어", "detail": "상세-한국어"},
+            "en": {"summary": "summary-en", "detail": "detail-en"},
+        },
+        ensure_ascii=False,
+    )
+
+    analysis_en, summary_en, detail_en, summary_i18n, detail_i18n = _parse_alert_analysis_result(
+        bilingual, "en"
+    )
+    assert summary_en == "summary-en"
+    assert detail_en == "detail-en"
+    assert "### 1) Summary" in analysis_en
+    assert summary_i18n == {"ko": "요약-한국어", "en": "summary-en"}
+    assert detail_i18n == {"ko": "상세-한국어", "en": "detail-en"}
+
+    analysis_ko, summary_ko, detail_ko, _, _ = _parse_alert_analysis_result(bilingual, "ko")
+    assert summary_ko == "요약-한국어"
+    assert detail_ko == "상세-한국어"
+    assert "### 1) 요약" in analysis_ko
+
+
+def test_parse_incident_summary_result_prefers_request_language() -> None:
+    from app.services.analysis import _parse_incident_summary_result
+
+    bilingual = json.dumps(
+        {
+            "title": "[svc] outage",
+            "ko": {"summary": "한국어 요약", "detail": "한국어 상세"},
+            "en": {"summary": "english summary", "detail": "english detail"},
+        },
+        ensure_ascii=False,
+    )
+
+    title_en, summary_en, detail_en, summary_i18n, detail_i18n = _parse_incident_summary_result(
+        bilingual, "fallback", "en"
+    )
+    assert title_en == "[svc] outage"
+    assert summary_en == "english summary"
+    assert detail_en == "english detail"
+    assert summary_i18n["ko"] == "한국어 요약"
+    assert detail_i18n["en"] == "english detail"
+
+    _, summary_ko, detail_ko, _, _ = _parse_incident_summary_result(bilingual, "fallback", "ko")
+    assert summary_ko == "한국어 요약"
+    assert detail_ko == "한국어 상세"
+
+
+def test_split_alert_analysis_handles_english_response() -> None:
+    from app.services.analysis import _split_alert_analysis
+
+    response_text = "### Summary\nPod restarted due to OOMKill.\n\n### Detail\nRoot cause is OOM."
+    summary, detail = _split_alert_analysis(response_text, "en")
+    assert "Pod restarted" in summary
+    assert "Root cause is OOM" in detail
+
+
+def test_parse_incident_summary_english_response() -> None:
+    response_text = (
+        "### Title\n"
+        "Outage on bookinfo\n\n"
+        "### Summary\n"
+        "Errors recovered after restart.\n\n"
+        "### Detail\n"
+        "#### Root Cause\n"
+        "- memory exhaustion\n"
+    )
+    title, summary, detail = _parse_incident_summary(response_text, "fallback", "en")
+    assert title == "Outage on bookinfo"
+    assert "Errors recovered" in summary
+    assert "Root Cause" in detail

--- a/agent/tests/test_config.py
+++ b/agent/tests/test_config.py
@@ -2,7 +2,12 @@ from __future__ import annotations
 
 import pytest
 
-from app.core.config import DEFAULT_ANTHROPIC_MAX_TOKENS, load_settings
+from app.core.config import (
+    DEFAULT_ANTHROPIC_MAX_TOKENS,
+    DEFAULT_LANGUAGE,
+    load_settings,
+    normalize_language,
+)
 
 
 def test_load_settings_parses_masking_regex_list_json(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -74,3 +79,43 @@ def test_load_settings_falls_back_for_invalid_anthropic_max_tokens(
     settings = load_settings()
 
     assert settings.anthropic_max_tokens == DEFAULT_ANTHROPIC_MAX_TOKENS
+
+
+def test_load_settings_language_defaults_to_en(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("LANGUAGE", raising=False)
+
+    settings = load_settings()
+
+    assert settings.language == DEFAULT_LANGUAGE == "en"
+
+
+@pytest.mark.parametrize(
+    "raw, expected",
+    [("ko", "ko"), ("en", "en"), ("KO", "ko"), ("  En  ", "en")],
+)
+def test_load_settings_language_accepts_supported_values(
+    monkeypatch: pytest.MonkeyPatch, raw: str, expected: str
+) -> None:
+    monkeypatch.setenv("LANGUAGE", raw)
+
+    settings = load_settings()
+
+    assert settings.language == expected
+
+
+@pytest.mark.parametrize("value", ["fr", "ja", "", "english"])
+def test_load_settings_language_invalid_falls_back_to_en(
+    monkeypatch: pytest.MonkeyPatch, value: str
+) -> None:
+    monkeypatch.setenv("LANGUAGE", value)
+
+    settings = load_settings()
+
+    assert settings.language == "en"
+
+
+def test_normalize_language_uses_default_for_invalid_value() -> None:
+    assert normalize_language("fr", default="ko") == "ko"
+    assert normalize_language(None, default="ko") == "ko"
+    # Invalid default itself falls back to "en"
+    assert normalize_language("fr", default="zz") == "en"

--- a/backend/internal/client/agent.go
+++ b/backend/internal/client/agent.go
@@ -61,6 +61,9 @@ type AgentClient struct {
 	retryMaxAttempts int
 	retryBaseBackoff time.Duration
 	retryMaxBackoff  time.Duration
+	// language is the backend default ("ko" or "en") attached to every Agent
+	// request payload (/analyze, /summarize-incident, /chat).
+	language string
 }
 
 // PreviousAnalysisContext - 이전 firing 분석 컨텍스트 (resolved 분석 시 참조)
@@ -78,6 +81,7 @@ type AgentAnalysisRequest struct {
 	IncidentID       string                   `json:"incident_id,omitempty"`
 	AnalysisType     string                   `json:"analysis_type,omitempty"`
 	PreviousAnalysis *PreviousAnalysisContext `json:"previous_analysis,omitempty"`
+	Language         string                   `json:"language,omitempty"`
 }
 
 // AgentAnalysisResponse 구조체 정의
@@ -102,6 +106,7 @@ type IncidentSummaryRequest struct {
 	FiredAt    string              `json:"fired_at"`
 	ResolvedAt string              `json:"resolved_at"`
 	Alerts     []AlertSummaryInput `json:"alerts"`
+	Language   string              `json:"language,omitempty"`
 }
 
 // AlertSummaryInput - 개별 Alert 분석 내용 (Agent에 전달)
@@ -178,12 +183,18 @@ func NewAgentClient(cfg config.AgentConfig) *AgentClient {
 		retryMaxBackoff = 15 * time.Second
 	}
 
+	language := cfg.Language
+	if language != "ko" && language != "en" {
+		language = "en"
+	}
+
 	log.Printf(
-		"Agent client initialized (base_url=%s, timeout_seconds=%d, retry_max_attempts=%d, retry_base_backoff=%s)",
+		"Agent client initialized (base_url=%s, timeout_seconds=%d, retry_max_attempts=%d, retry_base_backoff=%s, language=%s)",
 		baseURL,
 		timeoutSeconds,
 		retryMaxAttempts,
 		retryBaseBackoff,
+		language,
 	)
 
 	return &AgentClient{
@@ -194,6 +205,7 @@ func NewAgentClient(cfg config.AgentConfig) *AgentClient {
 		retryMaxAttempts: retryMaxAttempts,
 		retryBaseBackoff: retryBaseBackoff,
 		retryMaxBackoff:  retryMaxBackoff,
+		language:         language,
 	}
 }
 
@@ -245,6 +257,7 @@ func (c *AgentClient) doRequestAnalysis(alert model.Alert, threadTS, incidentID,
 		IncidentID:       incidentID,
 		AnalysisType:     analysisType,
 		PreviousAnalysis: prevAnalysis,
+		Language:         c.language,
 	}
 
 	payload, err := json.Marshal(req)
@@ -283,6 +296,10 @@ func (c *AgentClient) doRequestAnalysis(alert model.Alert, threadTS, incidentID,
 
 // POST /summarize-incident - Incident 최종 분석 요청
 func (c *AgentClient) RequestIncidentSummary(req IncidentSummaryRequest) (*IncidentSummaryResponse, error) {
+	if req.Language == "" {
+		req.Language = c.language
+	}
+
 	payload, err := json.Marshal(req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal incident summary request: %w", err)
@@ -321,6 +338,10 @@ func (c *AgentClient) RequestIncidentSummary(req IncidentSummaryRequest) (*Incid
 
 // POST /chat - Agent 채팅 요청
 func (c *AgentClient) RequestChat(ctx context.Context, req AgentChatRequest) (*AgentChatResponse, error) {
+	if req.Language == "" {
+		req.Language = c.language
+	}
+
 	payload, err := json.Marshal(req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal chat request: %w", err)

--- a/backend/internal/client/agent_retry_test.go
+++ b/backend/internal/client/agent_retry_test.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -163,5 +164,181 @@ func TestRequestAnalysis_ExhaustsRetries(t *testing.T) {
 	}
 	if callCount.Load() != 3 {
 		t.Errorf("expected 3 calls, got %d", callCount.Load())
+	}
+}
+
+// --- language payload propagation tests ---
+
+// newTestClientWithLanguage builds an AgentClient whose backend default
+// language is set via cfg, mirroring production wiring.
+func newTestClientWithLanguage(url, language string) *AgentClient {
+	cfg := config.AgentConfig{
+		BaseURL:              url,
+		HTTPTimeoutSeconds:   5,
+		RetryMaxAttempts:     1,
+		RetryBaseBackoffSecs: 0,
+		RetryMaxBackoffSecs:  0,
+		Language:             language,
+	}
+	return NewAgentClient(cfg)
+}
+
+func TestAgentClient_AnalyzePayloadContainsLanguageEn(t *testing.T) {
+	var captured AgentAnalysisRequest
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+			t.Fatalf("failed to decode body: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(AgentAnalysisResponse{Status: "ok"})
+	}))
+	defer server.Close()
+
+	c := newTestClientWithLanguage(server.URL, "en")
+	if _, err := c.RequestAnalysis(dummyAlert(), "ts-1", "inc-1", "firing", nil); err != nil {
+		t.Fatalf("RequestAnalysis error: %v", err)
+	}
+	if captured.Language != "en" {
+		t.Errorf("payload Language = %q, want %q", captured.Language, "en")
+	}
+}
+
+func TestAgentClient_AnalyzePayloadContainsLanguageKo(t *testing.T) {
+	var captured AgentAnalysisRequest
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+			t.Fatalf("failed to decode body: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(AgentAnalysisResponse{Status: "ok"})
+	}))
+	defer server.Close()
+
+	c := newTestClientWithLanguage(server.URL, "ko")
+	if _, err := c.RequestAnalysis(dummyAlert(), "ts-1", "inc-1", "firing", nil); err != nil {
+		t.Fatalf("RequestAnalysis error: %v", err)
+	}
+	if captured.Language != "ko" {
+		t.Errorf("payload Language = %q, want %q", captured.Language, "ko")
+	}
+}
+
+func TestAgentClient_AnalyzePayloadLanguageInvalidFallback(t *testing.T) {
+	var captured AgentAnalysisRequest
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+			t.Fatalf("failed to decode body: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(AgentAnalysisResponse{Status: "ok"})
+	}))
+	defer server.Close()
+
+	c := newTestClientWithLanguage(server.URL, "ja")
+	if _, err := c.RequestAnalysis(dummyAlert(), "ts-1", "inc-1", "firing", nil); err != nil {
+		t.Fatalf("RequestAnalysis error: %v", err)
+	}
+	if captured.Language != "en" {
+		t.Errorf("payload Language = %q, want en fallback", captured.Language)
+	}
+}
+
+func TestAgentClient_IncidentSummaryContainsLanguage(t *testing.T) {
+	var captured IncidentSummaryRequest
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+			t.Fatalf("failed to decode body: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(IncidentSummaryResponse{Status: "ok"})
+	}))
+	defer server.Close()
+
+	c := newTestClientWithLanguage(server.URL, "ko")
+	req := IncidentSummaryRequest{
+		IncidentID: "inc-1",
+		Title:      "test",
+	}
+	if _, err := c.RequestIncidentSummary(req); err != nil {
+		t.Fatalf("RequestIncidentSummary error: %v", err)
+	}
+	if captured.Language != "ko" {
+		t.Errorf("payload Language = %q, want ko", captured.Language)
+	}
+}
+
+func TestAgentClient_IncidentSummaryPreservesExplicitLanguage(t *testing.T) {
+	var captured IncidentSummaryRequest
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+			t.Fatalf("failed to decode body: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(IncidentSummaryResponse{Status: "ok"})
+	}))
+	defer server.Close()
+
+	// Backend default is "en", but caller explicitly sets "ko" — should be respected.
+	c := newTestClientWithLanguage(server.URL, "en")
+	req := IncidentSummaryRequest{
+		IncidentID: "inc-1",
+		Title:      "test",
+		Language:   "ko",
+	}
+	if _, err := c.RequestIncidentSummary(req); err != nil {
+		t.Fatalf("RequestIncidentSummary error: %v", err)
+	}
+	if captured.Language != "ko" {
+		t.Errorf("payload Language = %q, want explicit ko", captured.Language)
+	}
+}
+
+func TestAgentClient_ChatFallbackToBackendLanguage(t *testing.T) {
+	var captured AgentChatRequest
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+			t.Fatalf("failed to decode body: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(AgentChatResponse{Status: "ok", Answer: "hi"})
+	}))
+	defer server.Close()
+
+	c := newTestClientWithLanguage(server.URL, "ko")
+	req := AgentChatRequest{Message: "hello"}
+	if _, err := c.RequestChat(context.Background(), req); err != nil {
+		t.Fatalf("RequestChat error: %v", err)
+	}
+	if captured.Language != "ko" {
+		t.Errorf("payload Language = %q, want backend default ko", captured.Language)
+	}
+}
+
+func TestAgentClient_ChatPreservesExplicitLanguage(t *testing.T) {
+	var captured AgentChatRequest
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+			t.Fatalf("failed to decode body: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(AgentChatResponse{Status: "ok", Answer: "hi"})
+	}))
+	defer server.Close()
+
+	// Backend default is "en", caller passes "ko" — caller wins.
+	c := newTestClientWithLanguage(server.URL, "en")
+	req := AgentChatRequest{Message: "hello", Language: "ko"}
+	if _, err := c.RequestChat(context.Background(), req); err != nil {
+		t.Fatalf("RequestChat error: %v", err)
+	}
+	if captured.Language != "ko" {
+		t.Errorf("payload Language = %q, want caller ko", captured.Language)
 	}
 }

--- a/backend/internal/client/slack.go
+++ b/backend/internal/client/slack.go
@@ -31,6 +31,9 @@ type SlackClient struct {
 	channelID   string
 	frontendURL string
 	httpClient  *http.Client
+	// language is the normalized backend default ("ko" or "en") used to localize
+	// fixed Slack message strings (titles, prefixes, flapping bodies).
+	language string
 
 	// threadMap: fingerprint -> thread_ts 매핑
 	//   - resolved 알림을 firing과 같은 스레드로 보내기 위함
@@ -82,10 +85,15 @@ type SlackResponse struct {
 
 // SlackClient 객체 생성
 func NewSlackClient(cfg config.SlackConfig) *SlackClient {
+	language := cfg.Language
+	if language != "ko" && language != "en" {
+		language = "en"
+	}
 	return &SlackClient{
 		botToken:    cfg.BotToken,
 		channelID:   cfg.ChannelID,
 		frontendURL: strings.TrimRight(cfg.FrontendURL, "/"),
+		language:    language,
 		httpClient: &http.Client{
 			Timeout: 10 * time.Second,
 		},
@@ -242,7 +250,7 @@ func (c *SlackClient) SendToThreadInChannel(channelID, threadTS, text string) er
 		Attachments: []SlackAttachment{
 			{
 				Color: "#6f42c1", // purple for AI analysis
-				Title: "🤖 AI 분석 결과",
+				Title: c.t("analysis_result_title"),
 				Text:  toSlackMarkdown(text),
 				MrkdwnIn: []string{
 					"text",
@@ -339,4 +347,32 @@ func stripMarkdownBold(s string) string {
 		break
 	}
 	return s
+}
+
+// slackI18n holds localized Slack message strings keyed by language ("ko"|"en").
+// Add new keys here when introducing new fixed strings; do not export.
+var slackI18n = map[string]map[string]string{
+	"ko": {
+		"analysis_result_title":    "🤖 AI 분석 결과",
+		"manually_resolved_prefix": "🔧 [Manually Resolved]",
+		"incident_dashboard_link":  "🔍 Incident 대시보드 보러가기",
+		"flapping_detected_body":   "이 알림이 30분 내에 %d회 반복(firing→resolved)되어 Flapping으로 감지되었습니다.\n안정화될 때까지 추가 알림 및 AI 분석이 일시 중지됩니다.\n상태는 계속 추적되며, 30분간 안정 시 자동으로 해제됩니다.",
+		"flapping_cleared_body":    "이 알림이 30분 이상 안정 상태를 유지하여 Flapping 상태가 해제되었습니다.\n정상 알림 모니터링이 재개됩니다.",
+	},
+	"en": {
+		"analysis_result_title":    "🤖 AI Analysis",
+		"manually_resolved_prefix": "🔧 [Manually Resolved]",
+		"incident_dashboard_link":  "🔍 View incident dashboard",
+		"flapping_detected_body":   "This alert toggled (firing→resolved) %d times within 30 minutes and was detected as flapping.\nFurther notifications and AI analysis are paused until it stabilizes.\nIt will be cleared automatically after 30 minutes of stability.",
+		"flapping_cleared_body":    "This alert remained stable for over 30 minutes; flapping is now cleared.\nNormal alert monitoring has resumed.",
+	},
+}
+
+// t returns the localized Slack string for the given key, falling back to the
+// English entry if the language-specific entry is missing.
+func (c *SlackClient) t(key string) string {
+	if v, ok := slackI18n[c.language][key]; ok {
+		return v
+	}
+	return slackI18n["en"][key]
 }

--- a/backend/internal/client/slack_alert.go
+++ b/backend/internal/client/slack_alert.go
@@ -47,7 +47,8 @@ func (c *SlackClient) sendAlertWithThread(alert model.Alert, status, incidentID 
 
 	var title string
 	if isManual {
-		title = fmt.Sprintf("🔧 [Manually Resolved] [%s] %s",
+		title = fmt.Sprintf("%s [%s] %s",
+			c.t("manually_resolved_prefix"),
 			alert.Labels["severity"],
 			alert.Labels["alertname"],
 		)
@@ -68,7 +69,7 @@ func (c *SlackClient) sendAlertWithThread(alert model.Alert, status, incidentID 
 
 	// Incident 페이지 링크 추가
 	if incidentID != "" && c.frontendURL != "" {
-		incidentLink := fmt.Sprintf("<%s/incidents/%s|🔍 Incident 대시보드 보러가기>", c.frontendURL, incidentID)
+		incidentLink := fmt.Sprintf("<%s/incidents/%s|%s>", c.frontendURL, incidentID, c.t("incident_dashboard_link"))
 		fields = append(fields, SlackField{Title: "Incident", Value: incidentLink, Short: false})
 	}
 
@@ -152,12 +153,7 @@ func (c *SlackClient) SendFlappingDetectionInChannel(alert model.Alert, incident
 	emoji := "⚠️"
 	title := fmt.Sprintf("%s [FLAPPING DETECTED] %s", emoji, alert.Labels["alertname"])
 
-	description := fmt.Sprintf(
-		"이 알림이 30분 내에 %d회 반복(firing→resolved)되어 Flapping으로 감지되었습니다.\n"+
-			"안정화될 때까지 추가 알림 및 AI 분석이 일시 중지됩니다.\n"+
-			"상태는 계속 추적되며, 30분간 안정 시 자동으로 해제됩니다.",
-		cycleCount,
-	)
+	description := fmt.Sprintf(c.t("flapping_detected_body"), cycleCount)
 
 	fields := []SlackField{
 		{Title: "Alert Name", Value: alert.Labels["alertname"], Short: true},
@@ -221,7 +217,7 @@ func (c *SlackClient) SendFlappingClearedInChannel(channelID, threadTS string) e
 
 	emoji := "✅"
 	title := fmt.Sprintf("%s Flapping Cleared", emoji)
-	description := "이 알림이 30분 이상 안정 상태를 유지하여 Flapping 상태가 해제되었습니다.\n정상 알림 모니터링이 재개됩니다."
+	description := c.t("flapping_cleared_body")
 
 	msg := SlackMessage{
 		Channel:  channelID,

--- a/backend/internal/client/slack_test.go
+++ b/backend/internal/client/slack_test.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
+
+	"github.com/kube-rca/backend/internal/config"
 )
 
 func TestToSlackMarkdown(t *testing.T) {
@@ -70,6 +72,58 @@ func TestToSlackMarkdown(t *testing.T) {
 				t.Fatalf("toSlackMarkdown() = %q, want %q", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestSlackClient_LanguageEn_AnalysisTitle(t *testing.T) {
+	c := NewSlackClient(config.SlackConfig{Language: "en"})
+	if got := c.t("analysis_result_title"); got != "🤖 AI Analysis" {
+		t.Errorf("analysis_result_title (en) = %q, want %q", got, "🤖 AI Analysis")
+	}
+}
+
+func TestSlackClient_LanguageKo_AnalysisTitle(t *testing.T) {
+	c := NewSlackClient(config.SlackConfig{Language: "ko"})
+	if got := c.t("analysis_result_title"); got != "🤖 AI 분석 결과" {
+		t.Errorf("analysis_result_title (ko) = %q, want %q", got, "🤖 AI 분석 결과")
+	}
+}
+
+func TestSlackClient_LanguageInvalidFallback(t *testing.T) {
+	c := NewSlackClient(config.SlackConfig{Language: "invalid"})
+	// Invalid language is normalized to "en" at construction.
+	if got := c.t("analysis_result_title"); got != "🤖 AI Analysis" {
+		t.Errorf("analysis_result_title (invalid) = %q, want en fallback %q", got, "🤖 AI Analysis")
+	}
+	if got := c.t("incident_dashboard_link"); got != "🔍 View incident dashboard" {
+		t.Errorf("incident_dashboard_link (invalid) = %q, want en fallback", got)
+	}
+}
+
+func TestSlackClient_LanguageMissingKey_FallsBackToEn(t *testing.T) {
+	// Construct a ko-language client but request a key that does not exist in
+	// the ko map (simulated by mutating slackI18n locally would be invasive;
+	// instead verify the helper logic by checking that an unknown key returns
+	// the en value when present, and "" when absent in both).
+	c := NewSlackClient(config.SlackConfig{Language: "ko"})
+	if got := c.t("__unknown_key__"); got != "" {
+		t.Errorf("unknown key should return empty string, got %q", got)
+	}
+}
+
+func TestSlackClient_KoFlappingBody_ContainsCycleFormatter(t *testing.T) {
+	c := NewSlackClient(config.SlackConfig{Language: "ko"})
+	body := c.t("flapping_detected_body")
+	if !strings.Contains(body, "%d") {
+		t.Errorf("ko flapping_detected_body missing %%d formatter, got %q", body)
+	}
+}
+
+func TestSlackClient_EnFlappingBody_ContainsCycleFormatter(t *testing.T) {
+	c := NewSlackClient(config.SlackConfig{Language: "en"})
+	body := c.t("flapping_detected_body")
+	if !strings.Contains(body, "%d") {
+		t.Errorf("en flapping_detected_body missing %%d formatter, got %q", body)
 	}
 }
 

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"strconv"
+	"strings"
 
 	"github.com/joho/godotenv"
 )
@@ -18,6 +19,10 @@ type Config struct {
 	AI        AIConfig
 	Analysis  AnalysisConfig
 	Webhook   WebhookConfig
+	// Language is the backend-wide default language ("ko" or "en"), sourced from
+	// LANGUAGE env var. Used for Agent payloads (/analyze, /summarize-incident,
+	// /chat fallback) and Slack message i18n.
+	Language string
 }
 
 // WebhookConfig controls inbound /webhook/alertmanager hardening.
@@ -41,6 +46,9 @@ type SlackConfig struct {
 	BotToken    string
 	ChannelID   string
 	FrontendURL string
+	// Language is the normalized backend default ("ko" or "en") propagated from
+	// the top-level Config.Language. Used to localize Slack message strings.
+	Language string
 }
 
 type AgentConfig struct {
@@ -49,6 +57,10 @@ type AgentConfig struct {
 	RetryMaxAttempts     int
 	RetryBaseBackoffSecs int
 	RetryMaxBackoffSecs  int
+	// Language is the normalized backend default ("ko" or "en") propagated from
+	// the top-level Config.Language. Included in Agent /analyze, /summarize-incident,
+	// and /chat (fallback) payloads.
+	Language string
 }
 
 type EmbeddingConfig struct {
@@ -112,11 +124,14 @@ type AnalysisConfig struct {
 
 func Load() Config {
 	_ = godotenv.Load()
+	language := normalizeLanguage(os.Getenv("LANGUAGE"))
 	return Config{
+		Language: language,
 		Slack: SlackConfig{
 			BotToken:    os.Getenv("SLACK_BOT_TOKEN"),
 			ChannelID:   os.Getenv("SLACK_CHANNEL_ID"),
 			FrontendURL: os.Getenv("FRONTEND_URL"),
+			Language:    language,
 		},
 		Agent: AgentConfig{
 			BaseURL:              getenv("AGENT_URL", "http://kube-rca-agent.kube-rca.svc:8000"),
@@ -124,6 +139,7 @@ func Load() Config {
 			RetryMaxAttempts:     getenvInt("AGENT_RETRY_MAX_ATTEMPTS", 3),
 			RetryBaseBackoffSecs: getenvInt("AGENT_RETRY_BASE_BACKOFF_SECONDS", 5),
 			RetryMaxBackoffSecs:  getenvInt("AGENT_RETRY_MAX_BACKOFF_SECONDS", 15),
+			Language:             language,
 		},
 		Embedding: EmbeddingConfig{
 			Provider: getenv("EMBEDDING_PROVIDER", "google"),
@@ -208,4 +224,14 @@ func getenvBool(key string, fallback bool) bool {
 		}
 	}
 	return fallback
+}
+
+// normalizeLanguage returns "ko" or "en" only. Any other input (empty, invalid)
+// falls back to "en" — the OSS default. See AGENTS.md for project language policy.
+func normalizeLanguage(s string) string {
+	s = strings.ToLower(strings.TrimSpace(s))
+	if s == "ko" || s == "en" {
+		return s
+	}
+	return "en"
 }

--- a/backend/internal/config/config_test.go
+++ b/backend/internal/config/config_test.go
@@ -199,3 +199,87 @@ func TestLoad_PostgresDefaults(t *testing.T) {
 		t.Errorf("Postgres.SSLMode = %q, want disable", cfg.Postgres.SSLMode)
 	}
 }
+
+// TestLoad_LanguageDefaultsToEn verifies the OSS default language is "en"
+// when LANGUAGE is unset, and propagates to Slack/Agent sub-configs.
+func TestLoad_LanguageDefaultsToEn(t *testing.T) {
+	t.Setenv("LANGUAGE", "")
+
+	cfg := Load()
+
+	if cfg.Language != "en" {
+		t.Errorf("Language = %q, want en", cfg.Language)
+	}
+	if cfg.Slack.Language != "en" {
+		t.Errorf("Slack.Language = %q, want en", cfg.Slack.Language)
+	}
+	if cfg.Agent.Language != "en" {
+		t.Errorf("Agent.Language = %q, want en", cfg.Agent.Language)
+	}
+}
+
+// TestLoad_LanguageKo verifies LANGUAGE=ko is accepted and propagated.
+func TestLoad_LanguageKo(t *testing.T) {
+	t.Setenv("LANGUAGE", "ko")
+
+	cfg := Load()
+
+	if cfg.Language != "ko" {
+		t.Errorf("Language = %q, want ko", cfg.Language)
+	}
+	if cfg.Slack.Language != "ko" {
+		t.Errorf("Slack.Language = %q, want ko", cfg.Slack.Language)
+	}
+	if cfg.Agent.Language != "ko" {
+		t.Errorf("Agent.Language = %q, want ko", cfg.Agent.Language)
+	}
+}
+
+// TestLoad_LanguageCaseInsensitive verifies that uppercase LANGUAGE values are
+// normalized to lowercase.
+func TestLoad_LanguageCaseInsensitive(t *testing.T) {
+	t.Setenv("LANGUAGE", "KO")
+
+	cfg := Load()
+
+	if cfg.Language != "ko" {
+		t.Errorf("Language = %q, want ko", cfg.Language)
+	}
+}
+
+// TestLoad_LanguageInvalidFallsBackToEn verifies invalid LANGUAGE values fall
+// back to the OSS default ("en").
+func TestLoad_LanguageInvalidFallsBackToEn(t *testing.T) {
+	for _, raw := range []string{"ja", "fr", "kor", "english", " "} {
+		t.Setenv("LANGUAGE", raw)
+
+		cfg := Load()
+
+		if cfg.Language != "en" {
+			t.Errorf("LANGUAGE=%q: Language = %q, want en (fallback)", raw, cfg.Language)
+		}
+	}
+}
+
+// TestNormalizeLanguage verifies the normalizeLanguage helper directly so the
+// contract is locked in at the function boundary.
+func TestNormalizeLanguage(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"ko", "ko"},
+		{"en", "en"},
+		{"KO", "ko"},
+		{"En", "en"},
+		{" ko ", "ko"},
+		{"", "en"},
+		{"ja", "en"},
+		{"invalid", "en"},
+	}
+	for _, tt := range tests {
+		if got := normalizeLanguage(tt.input); got != tt.want {
+			t.Errorf("normalizeLanguage(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}

--- a/charts/kube-rca/README.md
+++ b/charts/kube-rca/README.md
@@ -510,6 +510,7 @@ backend:
 | hooks.waitJob.resources.limits.memory | string | `"32Mi"` |  |
 | hooks.waitJob.resources.requests.cpu | string | `"10m"` |  |
 | hooks.waitJob.resources.requests.memory | string | `"16Mi"` |  |
+| language | string | `"en"` | Response language for backend Slack messages and agent RCA results. Allowed: `ko` \| `en`. Default `en` — existing Korean users must explicitly set `language: ko` (BREAKING CHANGE). |
 | nameOverride | string | `""` | Override the name of the chart. |
 | openapi.affinity | object | `{}` | Affinity for OpenAPI pods assignment. |
 | openapi.baseUrl | string | `"/"` | Base URL for Swagger UI. |

--- a/charts/kube-rca/templates/_helpers.tpl
+++ b/charts/kube-rca/templates/_helpers.tpl
@@ -333,3 +333,11 @@ Agent service endpoint for wait-for-agent.
 {{- define "kube-rca.hook.agent.port" -}}
 {{- default 8000 .Values.agent.service.port -}}
 {{- end -}}
+
+{{/*
+Normalize language value. Returns one of: ko, en. Default en.
+*/}}
+{{- define "kube-rca.language" -}}
+{{- $lang := default "en" .Values.language | lower -}}
+{{- if has $lang (list "ko" "en") -}}{{ $lang }}{{- else -}}en{{- end -}}
+{{- end -}}

--- a/charts/kube-rca/templates/agent/deployment.yaml
+++ b/charts/kube-rca/templates/agent/deployment.yaml
@@ -56,6 +56,8 @@ spec:
               value: {{ default 1 .Values.agent.workers | quote }}
             - name: LOG_LEVEL
               value: {{ .Values.agent.logLevel | quote }}
+            - name: LANGUAGE
+              value: {{ include "kube-rca.language" . | quote }}
             - name: AI_PROVIDER
               value: {{ default "gemini" .Values.agent.aiProvider | quote }}
             - name: GEMINI_MODEL_ID

--- a/charts/kube-rca/templates/backend/deployment.yaml
+++ b/charts/kube-rca/templates/backend/deployment.yaml
@@ -63,6 +63,8 @@ spec:
                   key: {{ default "password" $pgSecret.key | quote }}
             - name: PGDATABASE
               value: {{ default "kube-rca" .Values.backend.postgresql.database | quote }}
+            - name: LANGUAGE
+              value: {{ include "kube-rca.language" . | quote }}
             {{- $auth := default (dict) .Values.backend.auth }}
             {{- if $auth.enabled }}
             {{- $authSecret := default (dict) $auth.secret }}

--- a/charts/kube-rca/values.yaml
+++ b/charts/kube-rca/values.yaml
@@ -1,5 +1,9 @@
 nameOverride: ''
 fullnameOverride: ''
+# 응답 언어. backend Slack 메시지와 agent RCA 분석 결과에 적용.
+# 허용 값: ko | en
+# 기본값 en — 기존 한국어 사용자는 명시적으로 `language: ko` 지정 필요. (BREAKING CHANGE)
+language: en
 hooks:
   enabled: true
   waitJob:


### PR DESCRIPTION
## Summary

`helm values.yaml`의 단일 `language: ko|en` 값으로 **RCA 분석 결과**와 **Slack 스레드 메시지** 양쪽을 통합 제어합니다. 기존에 한국어로 하드코딩되어 있던 흐름을 i18n 가능한 구조로 전환했습니다.

## ⚠️ BREAKING CHANGE

기본값이 `en`으로 변경됩니다. **기존 한국어 운영 클러스터**는 helm upgrade 시 분석/Slack 메시지가 영어로 전환됩니다.

마이그레이션:
```yaml
# values.yaml
language: ko
```
또는:
```bash
helm upgrade kube-rca charts/kube-rca --set language=ko
```

## Changes per Component

| 컴포넌트 | 파일 | 핵심 변경 |
|---------|------|----------|
| **Helm** (5) | `values.yaml`, `_helpers.tpl`, `backend/deployment.yaml`, `agent/deployment.yaml`, `README.md` | top-level `language: en` + `kube-rca.language` helper → 두 Deployment에 `LANGUAGE` env 주입. invalid 입력은 `en`으로 정규화. |
| **Agent** (7) | `core/config.py`, `core/dependencies.py`, `schemas/analysis.py`, `services/analysis.py`, `services/chat.py`, `tests/test_analysis_service.py`, `tests/test_config.py` | `Settings.language`(env `LANGUAGE`) + `normalize_language`/`_headers(lang)` 헬퍼. `analysis.py` prompt 섹션 헤더(`근본 원인`/`Root Cause` 등) · 응답 파서 키 우선순위 · fallback 텍스트 · incident summary prompt 모두 ko/en 분기. `chat.py`는 `settings.language` fallback 보강. **20 new tests.** |
| **Backend** (7) | `config/config.go`, `config/config_test.go`, `client/agent.go`, `client/agent_retry_test.go`, `client/slack.go`, `client/slack_alert.go`, `client/slack_test.go` | `Config.Language` + `normalizeLanguage`. AgentClient는 `/analyze` / `/summarize-incident` / `/chat` payload에 `language` 필드 항상 포함. SlackClient에 `slackI18n` 맵 + `c.t(key)` helper로 5곳(분석 결과 타이틀, 수동 resolve prefix, incident 대시보드 링크, flapping detected/cleared 안내)을 ko/en 분기. **18 new tests.** |

총 **19 파일 / +1014 / -81 라인** (대부분 신규 테스트 574줄과 분기 패턴 반복).

## Wire Contract (Backend ↔ Agent)

`POST /analyze`, `POST /summarize-incident`, `POST /chat` 요청 body에 신규 optional 필드:

```json
{
  "...": "...",
  "language": "en"
}
```

Agent는 `language` 필드가 없거나 `null`이면 `settings.language`(env `LANGUAGE`)로 fallback. Backend는 호출 시 항상 자기 `Config.Language`를 채워 보냅니다.

## Verification

| 검증 | 결과 |
|------|-----|
| `helm lint charts/kube-rca` | ✅ pass |
| `helm template ... --set language=en\|ko\|invalid` | ✅ `"en"` / `"ko"` / `"en"` (fallback 정상) |
| `gofmt -l . && go vet ./... && go test ./internal/{config,client}/...` | ✅ pass (config/client 144 PASS) |
| `uv run ruff check app tests` | ✅ All checks passed |
| `uv run mypy --ignore-missing-imports app` | ✅ baseline 동등 (47 = 47, no new errors) |
| `uv run pytest tests/test_analysis_service.py tests/test_config.py` | ✅ 103 passed |

CI gate("no new mypy errors")를 baseline과 동등 결과로 통과합니다. 분석 라인 시프트는 새 헬퍼 함수가 위쪽에 추가되어 발생한 시각적 차이일 뿐 동일 baseline 에러입니다.

## Out of Scope (별도 PR)

- Frontend UI i18n (react-i18next 등) — 이번 변경 범위 아님
- 과거 저장된 `alerts.analysis_summary` 등 DB 데이터 — 생성 시점 언어 그대로 유지 (마이그레이션 불필요)
- LLM 응답 품질 회귀 모니터링 — en 모드 첫 배포 후 샘플 리뷰 권장

## Plan

설계 문서: `~/.claude/plans/memoized-twirling-dewdrop.md`
