### PR TITLE
chore(ci): switch dependabot to monthly and group docker updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,5 @@
 # Dependabot keeps each component's dependency graph fresh.
-# Updates are grouped by ecosystem so we get one PR per group per week
+# Updates are grouped by ecosystem so we get one PR per group per month
 # instead of dozens of single-package PRs.
 #
 # Ecosystems covered:
@@ -15,8 +15,7 @@ updates:
   - package-ecosystem: "gomod"
     directory: "/backend"
     schedule:
-      interval: "weekly"
-      day: "monday"
+      interval: "monthly"
       time: "06:00"
       timezone: "Asia/Seoul"
     open-pull-requests-limit: 5
@@ -36,8 +35,7 @@ updates:
   - package-ecosystem: "pip"
     directory: "/agent"
     schedule:
-      interval: "weekly"
-      day: "monday"
+      interval: "monthly"
       time: "06:00"
       timezone: "Asia/Seoul"
     open-pull-requests-limit: 5
@@ -57,8 +55,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/frontend"
     schedule:
-      interval: "weekly"
-      day: "monday"
+      interval: "monthly"
       time: "06:00"
       timezone: "Asia/Seoul"
     open-pull-requests-limit: 5
@@ -78,8 +75,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
-      day: "monday"
+      interval: "monthly"
       time: "06:00"
       timezone: "Asia/Seoul"
     open-pull-requests-limit: 5
@@ -99,8 +95,7 @@ updates:
   - package-ecosystem: "docker"
     directory: "/backend"
     schedule:
-      interval: "weekly"
-      day: "monday"
+      interval: "monthly"
       time: "06:00"
       timezone: "Asia/Seoul"
     open-pull-requests-limit: 3
@@ -110,12 +105,15 @@ updates:
       - "dependencies"
       - "docker"
       - "backend"
+    groups:
+      backend-docker:
+        patterns:
+          - "*"
 
   - package-ecosystem: "docker"
     directory: "/frontend"
     schedule:
-      interval: "weekly"
-      day: "monday"
+      interval: "monthly"
       time: "06:00"
       timezone: "Asia/Seoul"
     open-pull-requests-limit: 3
@@ -125,12 +123,15 @@ updates:
       - "dependencies"
       - "docker"
       - "frontend"
+    groups:
+      frontend-docker:
+        patterns:
+          - "*"
 
   - package-ecosystem: "docker"
     directory: "/agent"
     schedule:
-      interval: "weekly"
-      day: "monday"
+      interval: "monthly"
       time: "06:00"
       timezone: "Asia/Seoul"
     open-pull-requests-limit: 3
@@ -140,3 +141,7 @@ updates:
       - "dependencies"
       - "docker"
       - "agent"
+    groups:
+      agent-docker:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary

dependabot PR/notification 볼륨을 줄이기 위한 설정 조정입니다.

- **전체 7개 ecosystem: `weekly` -> `monthly`** (`day: monday`는 weekly 전용이라 제거. monthly는 매월 1일 06:00 KST 실행)
- **docker 3개(backend/frontend/agent): catch-all 그룹 추가** (`patterns: ["*"]`). 그동안 그룹이 없어 base image digest 변경마다 개별 PR(예: #108 nginx)이 났는데, 이제 Dockerfile 디렉터리당 1 PR로 수렴

## Trade-offs

- go/pip/npm/actions의 기존 minor/patch 그룹은 그대로 유지 -> major bump은 분리된 채로 남아 grouped PR 머지를 막지 않습니다.
- 의존성 신선도가 최대 한 달까지 지연될 수 있으나, **Dependabot security updates는 version-update schedule과 무관하게 즉시 PR을 올리므로** 보안 패치 속도는 영향받지 않습니다.

## Verification

- YAML parse + 구조 확인 통과 (updates 7개 항목, 각 ecosystem interval=monthly, docker 3개 group 적용)