### PR TITLE
chore: switch container registry from ECR Public to GHCR

### DIFF
--- a/.github/workflows/ci-agent.yaml
+++ b/.github/workflows/ci-agent.yaml
@@ -70,7 +70,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write   # commit helm-values bump back to main
-      id-token: write   # AWS OIDC for ECR Public push
+      packages: write   # push image to GHCR
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
@@ -87,30 +87,22 @@ jobs:
       - name: Test
         working-directory: agent
         run: pytest
-      - name: Configure AWS credentials (OIDC)
-        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
+      - name: Log in to GHCR
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
-          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
-          aws-region: ap-northeast-2
-          role-session-name: github-actions-agent
-      - name: Login to ECR Public
-        id: ecr
-        uses: aws-actions/amazon-ecr-login@4625ce35226a7557230889aae2f52eb50ec3dcda # v2.0.1
-        with:
-          registry-type: public
-        env:
-          AWS_DEFAULT_REGION: us-east-1
-          AWS_REGION: us-east-1
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Set image tag
         id: tag
         run: echo "image_tag=agent-${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
       - name: Build and push
         run: |
           docker build \
-            -t "${{ steps.ecr.outputs.registry }}/r5b7j2e4/kube-rca-ecr/agent:${{ steps.tag.outputs.image_tag }}" \
+            -t "ghcr.io/kube-rca/agent:${{ steps.tag.outputs.image_tag }}" \
             agent/
           docker push \
-            "${{ steps.ecr.outputs.registry }}/r5b7j2e4/kube-rca-ecr/agent:${{ steps.tag.outputs.image_tag }}"
+            "ghcr.io/kube-rca/agent:${{ steps.tag.outputs.image_tag }}"
       - name: Update helm values (agent image tag)
         uses: mikefarah/yq@751d8ad57b84f1794661bc70c0afb92a22ad7b3c # v4.53.2
         with:

--- a/.github/workflows/ci-backend.yaml
+++ b/.github/workflows/ci-backend.yaml
@@ -100,33 +100,25 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write   # commit helm-values bump back to main
-      id-token: write   # AWS OIDC for ECR Public push
+      packages: write   # push image to GHCR
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - name: Configure AWS credentials (OIDC)
-        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
+      - name: Log in to GHCR
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
-          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
-          aws-region: ap-northeast-2
-          role-session-name: github-actions-backend
-      - name: Login to ECR Public
-        id: ecr
-        uses: aws-actions/amazon-ecr-login@4625ce35226a7557230889aae2f52eb50ec3dcda # v2.0.1
-        with:
-          registry-type: public
-        env:
-          AWS_DEFAULT_REGION: us-east-1
-          AWS_REGION: us-east-1
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Set image tag
         id: tag
         run: echo "image_tag=backend-${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
       - name: Build and push
         run: |
           docker build \
-            -t "${{ steps.ecr.outputs.registry }}/r5b7j2e4/kube-rca-ecr/backend:${{ steps.tag.outputs.image_tag }}" \
+            -t "ghcr.io/kube-rca/backend:${{ steps.tag.outputs.image_tag }}" \
             backend/
           docker push \
-            "${{ steps.ecr.outputs.registry }}/r5b7j2e4/kube-rca-ecr/backend:${{ steps.tag.outputs.image_tag }}"
+            "ghcr.io/kube-rca/backend:${{ steps.tag.outputs.image_tag }}"
       - name: Update helm values (backend image tag)
         uses: mikefarah/yq@751d8ad57b84f1794661bc70c0afb92a22ad7b3c # v4.53.2
         with:

--- a/.github/workflows/ci-frontend.yaml
+++ b/.github/workflows/ci-frontend.yaml
@@ -58,33 +58,25 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write   # commit helm-values bump back to main
-      id-token: write   # AWS OIDC for ECR Public push
+      packages: write   # push image to GHCR
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - name: Configure AWS credentials (OIDC)
-        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
+      - name: Log in to GHCR
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
-          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
-          aws-region: ap-northeast-2
-          role-session-name: github-actions-frontend
-      - name: Login to ECR Public
-        id: ecr
-        uses: aws-actions/amazon-ecr-login@4625ce35226a7557230889aae2f52eb50ec3dcda # v2.0.1
-        with:
-          registry-type: public
-        env:
-          AWS_DEFAULT_REGION: us-east-1
-          AWS_REGION: us-east-1
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Set image tag
         id: tag
         run: echo "image_tag=frontend-${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
       - name: Build and push
         run: |
           docker build \
-            -t "${{ steps.ecr.outputs.registry }}/r5b7j2e4/kube-rca-ecr/frontend:${{ steps.tag.outputs.image_tag }}" \
+            -t "ghcr.io/kube-rca/frontend:${{ steps.tag.outputs.image_tag }}" \
             frontend/
           docker push \
-            "${{ steps.ecr.outputs.registry }}/r5b7j2e4/kube-rca-ecr/frontend:${{ steps.tag.outputs.image_tag }}"
+            "ghcr.io/kube-rca/frontend:${{ steps.tag.outputs.image_tag }}"
       - name: Update helm values (frontend image tag)
         uses: mikefarah/yq@751d8ad57b84f1794661bc70c0afb92a22ad7b3c # v4.53.2
         with:

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -43,23 +43,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
-      - name: Configure AWS credentials (OIDC)
-        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
-        with:
-          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
-          aws-region: ap-northeast-2
-          role-session-name: github-actions-${{ matrix.component }}
-
-      - name: Login to ECR Public
-        id: ecr
-        uses: aws-actions/amazon-ecr-login@4625ce35226a7557230889aae2f52eb50ec3dcda # v2.0.1
-        with:
-          registry-type: public
-        env:
-          AWS_DEFAULT_REGION: us-east-1
-          AWS_REGION: us-east-1
-
-      - name: Login to ghcr.io (mirror)
+      - name: Log in to GHCR
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ghcr.io
@@ -70,12 +54,8 @@ jobs:
         id: refs
         run: |
           TAG="${{ needs.release-please.outputs.tag_name }}"
-          ECR_IMAGE="${{ steps.ecr.outputs.registry }}/r5b7j2e4/kube-rca-ecr/${{ matrix.component }}:${TAG}"
           GHCR_IMAGE="ghcr.io/kube-rca/${{ matrix.component }}:${TAG}"
-          {
-            echo "ecr_image=${ECR_IMAGE}"
-            echo "ghcr_image=${GHCR_IMAGE}"
-          } >> "$GITHUB_OUTPUT"
+          echo "ghcr_image=${GHCR_IMAGE}" >> "$GITHUB_OUTPUT"
 
       - name: Build and push
         id: build
@@ -86,7 +66,6 @@ jobs:
           provenance: true
           sbom: true
           tags: |
-            ${{ steps.refs.outputs.ecr_image }}
             ${{ steps.refs.outputs.ghcr_image }}
 
       - name: Install cosign
@@ -96,25 +75,17 @@ jobs:
         env:
           COSIGN_EXPERIMENTAL: "1"
         run: |
-          cosign sign --yes "${{ steps.refs.outputs.ecr_image }}@${{ steps.build.outputs.digest }}"
           cosign sign --yes "${{ steps.refs.outputs.ghcr_image }}@${{ steps.build.outputs.digest }}"
 
       - name: Generate SBOM (SPDX JSON)
         uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
         with:
-          image: ${{ steps.refs.outputs.ecr_image }}
+          image: ${{ steps.refs.outputs.ghcr_image }}
           format: spdx-json
           artifact-name: ${{ matrix.component }}-sbom.spdx.json
           output-file: ${{ matrix.component }}-sbom.spdx.json
 
-      - name: Attest build provenance (ECR)
-        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2.4.0
-        with:
-          subject-name: ${{ steps.refs.outputs.ecr_image }}
-          subject-digest: ${{ steps.build.outputs.digest }}
-          push-to-registry: true
-
-      - name: Attest build provenance (ghcr)
+      - name: Attest build provenance
         uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2.4.0
         with:
           subject-name: ${{ steps.refs.outputs.ghcr_image }}
@@ -124,7 +95,7 @@ jobs:
       - name: Trivy vulnerability scan
         uses: aquasecurity/trivy-action@a9c7b0f06e461e9d4b4d1711f154ee024b8d7ab8 # v0.36.0
         with:
-          image-ref: ${{ steps.refs.outputs.ecr_image }}
+          image-ref: ${{ steps.refs.outputs.ghcr_image }}
           severity: CRITICAL,HIGH
           exit-code: "1"
           ignore-unfixed: true
@@ -137,7 +108,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      id-token: write
+      packages: write   # push chart to GHCR (OCI)
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
@@ -145,19 +116,13 @@ jobs:
       - uses: azure/setup-helm@fe7b79cd5ee1e45176fcad797de68ecaf3ca4814 # v4.2.0
       - name: Add Bitnami chart repo
         run: helm repo add bitnami https://charts.bitnami.com/bitnami --force-update
-      - name: Configure AWS credentials (OIDC)
-        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
-        with:
-          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
-          aws-region: ap-northeast-2
-          role-session-name: github-actions-helm
-      - name: Login to ECR Public (OCI)
+      - name: Login to GHCR (OCI)
         run: |
-          aws ecr-public get-login-password --region us-east-1 | \
-            helm registry login --username AWS --password-stdin public.ecr.aws
+          echo "${{ secrets.GITHUB_TOKEN }}" | \
+            helm registry login ghcr.io --username ${{ github.actor }} --password-stdin
       - name: Build chart dependencies
         run: helm dependency build charts/kube-rca
       - name: Package chart
         run: helm package charts/kube-rca
-      - name: Push chart to ECR
-        run: helm push kube-rca-*.tgz oci://public.ecr.aws/r5b7j2e4/kube-rca-ecr/charts
+      - name: Push chart to GHCR
+        run: helm push kube-rca-*.tgz oci://ghcr.io/kube-rca/charts

--- a/charts/kube-rca/README.md
+++ b/charts/kube-rca/README.md
@@ -64,7 +64,7 @@ frontend:
 **Option A — From OCI Registry (recommended):**
 
 ```bash
-helm upgrade --install kube-rca oci://public.ecr.aws/r5b7j2e4/kube-rca-ecr/charts/kube-rca \
+helm upgrade --install kube-rca oci://ghcr.io/kube-rca/charts/kube-rca \
   -n kube-rca --create-namespace \
   -f my-values.yaml
 ```
@@ -337,7 +337,7 @@ backend:
 | agent.gemini.secret.existingSecret | string | `"kube-rca-ai"` | Existing Secret name for the Gemini API key. |
 | agent.gemini.secret.key | string | `"ai-studio-api-key"` | Secret key name for the Gemini API key. |
 | agent.image.pullPolicy | string | `"IfNotPresent"` | Agent image pull policy. |
-| agent.image.repository | string | `"public.ecr.aws/r5b7j2e4/kube-rca-ecr/agent"` | Agent image repository. |
+| agent.image.repository | string | `"ghcr.io/kube-rca/agent"` | Agent image repository. |
 | agent.image.tag | string | `"1.3.0"` | Agent image tag. Synced by release-please from manifest version. |
 | agent.ingress.annotations | object | `{}` | Annotations for agent ingress. |
 | agent.ingress.enabled | bool | `false` | Enable agent ingress. |
@@ -432,7 +432,7 @@ backend:
 | backend.flapping.detectionWindowMinutes | int | `30` | Time window (minutes) for detecting flapping cycles (FLAP_DETECTION_WINDOW_MINUTES). |
 | backend.flapping.enabled | bool | `true` | Enable alert flapping detection (FLAP_ENABLED). |
 | backend.image.pullPolicy | string | `"IfNotPresent"` | Backend image pull policy. |
-| backend.image.repository | string | `"public.ecr.aws/r5b7j2e4/kube-rca-ecr/backend"` | Backend image repository. |
+| backend.image.repository | string | `"ghcr.io/kube-rca/backend"` | Backend image repository. |
 | backend.image.tag | string | `"1.3.0"` | Backend image tag. Synced by release-please from manifest version. |
 | backend.ingress.annotations | object | `{}` | Annotations for backend ingress. |
 | backend.ingress.enabled | bool | `false` | Enable backend ingress. |
@@ -475,7 +475,7 @@ backend:
 | frontend.affinity | object | `{}` | Affinity for frontend pods assignment. |
 | frontend.containerPort | int | `80` | Frontend container port. |
 | frontend.image.pullPolicy | string | `"IfNotPresent"` | Frontend image pull policy. |
-| frontend.image.repository | string | `"public.ecr.aws/r5b7j2e4/kube-rca-ecr/frontend"` | Frontend image repository. |
+| frontend.image.repository | string | `"ghcr.io/kube-rca/frontend"` | Frontend image repository. |
 | frontend.image.tag | string | `"1.3.0"` | Frontend image tag. Synced by release-please from manifest version. |
 | frontend.ingress.annotations | object | `{}` | Annotations for frontend ingress. |
 | frontend.ingress.enabled | bool | `false` | Enable frontend ingress. |

--- a/charts/kube-rca/README.md.gotmpl
+++ b/charts/kube-rca/README.md.gotmpl
@@ -63,7 +63,7 @@ frontend:
 **Option A — From OCI Registry (recommended):**
 
 ```bash
-helm upgrade --install kube-rca oci://public.ecr.aws/r5b7j2e4/kube-rca-ecr/charts/kube-rca \
+helm upgrade --install kube-rca oci://ghcr.io/kube-rca/charts/kube-rca \
   -n kube-rca --create-namespace \
   -f my-values.yaml
 ```

--- a/charts/kube-rca/kube-rca-eks-values.yaml
+++ b/charts/kube-rca/kube-rca-eks-values.yaml
@@ -1,6 +1,6 @@
 backend:
   image:
-    repository: public.ecr.aws/r5b7j2e4/kube-rca-ecr/backend
+    repository: ghcr.io/kube-rca/backend
     tag: backend-2961b49
   auth:
     secret:
@@ -41,7 +41,7 @@ backend:
           - api-kuberca2.kkamji.net
 frontend:
   image:
-    repository: public.ecr.aws/r5b7j2e4/kube-rca-ecr/frontend
+    repository: ghcr.io/kube-rca/frontend
     tag: frontend-65a19e8
   ingress:
     enabled: true
@@ -70,7 +70,7 @@ postgresql:
         memory: 512Mi
 agent:
   image:
-    repository: public.ecr.aws/r5b7j2e4/kube-rca-ecr/agent
+    repository: ghcr.io/kube-rca/agent
     tag: agent-31c116c
   workers: 4
   aiProvider: gemini

--- a/charts/kube-rca/kube-rca-values.yaml
+++ b/charts/kube-rca/kube-rca-values.yaml
@@ -1,6 +1,6 @@
 backend:
   image:
-    repository: public.ecr.aws/r5b7j2e4/kube-rca-ecr/backend
+    repository: ghcr.io/kube-rca/backend
     tag: backend-da93bc9
   auth:
     secret:
@@ -42,7 +42,7 @@ backend:
           - api-kuberca.kkamji.net
 frontend:
   image:
-    repository: public.ecr.aws/r5b7j2e4/kube-rca-ecr/frontend
+    repository: ghcr.io/kube-rca/frontend
     tag: frontend-da93bc9
   ingress:
     enabled: true
@@ -70,7 +70,7 @@ postgresql:
         memory: 512Mi
 agent:
   image:
-    repository: public.ecr.aws/r5b7j2e4/kube-rca-ecr/agent
+    repository: ghcr.io/kube-rca/agent
     tag: agent-da93bc9
   workers: 4
   aiProvider: gemini

--- a/charts/kube-rca/values.yaml
+++ b/charts/kube-rca/values.yaml
@@ -68,7 +68,7 @@ postgresql:
 backend:
   replicaCount: 1
   image:
-    repository: public.ecr.aws/r5b7j2e4/kube-rca-ecr/backend
+    repository: ghcr.io/kube-rca/backend
     tag: 1.4.0
     pullPolicy: IfNotPresent
   service:
@@ -173,7 +173,7 @@ backend:
 agent:
   replicaCount: 2
   image:
-    repository: public.ecr.aws/r5b7j2e4/kube-rca-ecr/agent
+    repository: ghcr.io/kube-rca/agent
     tag: 1.4.0
     pullPolicy: IfNotPresent
   service:
@@ -272,7 +272,7 @@ agent:
 frontend:
   replicaCount: 1
   image:
-    repository: public.ecr.aws/r5b7j2e4/kube-rca-ecr/frontend
+    repository: ghcr.io/kube-rca/frontend
     tag: 1.4.0
     pullPolicy: IfNotPresent
   service:

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -136,7 +136,7 @@ For the source of truth, see `agent/tests/test_masking.py` in the repo — it do
 `helm upgrade` is generally safe between minor versions:
 
 ```bash
-helm upgrade kube-rca oci://public.ecr.aws/r5b7j2e4/kube-rca-ecr/charts/kube-rca \
+helm upgrade kube-rca oci://ghcr.io/kube-rca/charts/kube-rca \
   -n kube-rca \
   -f my-values.yaml
 ```

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -155,13 +155,13 @@ The host, scheme, and path must match exactly. After editing, `helm upgrade` and
 
 **Symptom**
 
-Pods stuck in `ImagePullBackOff`. `kubectl describe pod` shows errors pulling from `public.ecr.aws/r5b7j2e4/kube-rca-ecr/...`.
+Pods stuck in `ImagePullBackOff`. `kubectl describe pod` shows errors pulling from `ghcr.io/kube-rca/...`.
 
 **Cause**
 
 ECR Public *does* allow anonymous pulls — no credentials needed. So this is almost always a node-side networking or DNS issue:
 
-- The cluster cannot reach `public.ecr.aws` (egress firewall, NAT gateway, no IPv4 route)
+- The cluster cannot reach `ghcr.io` (egress firewall, NAT gateway, no IPv4 route)
 - Region-restricted egress policy blocks `*.amazonaws.com`
 - Stale image cache after an image tag was force-pushed (rare)
 
@@ -172,7 +172,7 @@ ECR Public *does* allow anonymous pulls — no credentials needed. So this is al
    ```bash
    kubectl run --rm -it --image=alpine:3 net-debug -- sh
    apk add --no-cache curl
-   curl -sI https://public.ecr.aws/v2/
+   curl -sI https://ghcr.io/v2/
    ```
 
    You should get a 401 (challenge) — that proves DNS + TLS work.
@@ -182,7 +182,7 @@ ECR Public *does* allow anonymous pulls — no credentials needed. So this is al
 3. Verify the tag actually exists:
 
    ```bash
-   docker pull public.ecr.aws/r5b7j2e4/kube-rca-ecr/backend:backend-0.5.1
+   docker pull ghcr.io/kube-rca/backend:backend-0.5.1
    ```
 
 ---

--- a/docs/installation-guide-en.md
+++ b/docs/installation-guide-en.md
@@ -85,7 +85,7 @@ agent:
 ### Step 2: Install with Helm
 
 ```bash
-helm upgrade --install kube-rca oci://public.ecr.aws/r5b7j2e4/kube-rca-ecr/charts/kube-rca \
+helm upgrade --install kube-rca oci://ghcr.io/kube-rca/charts/kube-rca \
   -n kube-rca --create-namespace \
   -f my-values.yaml
 ```

--- a/docs/installation-guide-ko.md
+++ b/docs/installation-guide-ko.md
@@ -85,7 +85,7 @@ agent:
 ### 2단계: Helm 설치
 
 ```bash
-helm upgrade --install kube-rca oci://public.ecr.aws/r5b7j2e4/kube-rca-ecr/charts/kube-rca \
+helm upgrade --install kube-rca oci://ghcr.io/kube-rca/charts/kube-rca \
   -n kube-rca --create-namespace \
   -f my-values.yaml
 ```


### PR DESCRIPTION
## Summary

이미지/Helm 차트 퍼블리싱을 AWS ECR Public -> **GitHub Container Registry(`ghcr.io/kube-rca`)** 로 전환합니다. CI의 AWS OIDC/IAM 의존성을 통째로 제거하고 빌트인 `GITHUB_TOKEN`(`packages: write`)으로 인증합니다.

이로써 최근 main의 `build-and-push` 실패 원인(`Could not assume role with OIDC: No OpenIDConnect provider found`)도 해소됩니다. 해당 어드바이저리/인프라 드리프트는 코드와 무관했고, GHCR 전환으로 AWS 인증 경로 자체가 사라집니다.

## 변경

**CI (`ci-backend/frontend/agent` build-and-push)**
- `aws-actions/configure-aws-credentials` + `amazon-ecr-login` 제거
- `docker/login-action`으로 ghcr.io 로그인 (`GITHUB_TOKEN`)
- push 대상 `ghcr.io/kube-rca/<comp>:<comp>-<sha>` (태그 스킴 동일)
- permissions: `id-token:write` -> `packages:write`

**release-please (`publish-images` / `publish-helm`)**
- ECR+GHCR 미러 -> GHCR 단일. cosign keyless / SBOM / provenance / Trivy 모두 GHCR 이미지 대상
- 차트 OCI push -> `oci://ghcr.io/kube-rca/charts`

**Helm values + 문서**
- backend/frontend/agent `image.repository` 기본값 -> `ghcr.io/kube-rca/<comp>` (`values.yaml`, `kube-rca-values.yaml`, `kube-rca-eks-values.yaml`)
- `README(.gotmpl)`, `FAQ`, install guides, `TROUBLESHOOTING` 경로 갱신

## 결정 사항 반영
- **Hard switch (GHCR only)**, dual-publish 없음
- values 키는 동일(기본 registry만 변경) -> **breaking chart-API 아님**, breaking 라벨/footer 없음
- 경로는 flat `ghcr.io/kube-rca/<comp>`
- Terraform OIDC/ECR-public 리소스 정리는 **별도 PR**

## Verification
- 워크플로우 4개 valid YAML
- `helm lint charts/kube-rca` 통과 (deps build 포함)
- `public.ecr.aws` / `r5b7j2e4` / `amazon-ecr-login` 잔존 참조 0

## 머지 후 확인 필요 (post-merge)
- `build-and-push`는 main 전용이라 이 PR CI에선 실행되지 않음 -> **머지 후 첫 main 푸시에서 GHCR push 실증**
- GHCR 패키지 최초 생성 시 org 패키지 **visibility(public 공개)** 1회 설정 필요할 수 있음