### PR TITLE
fix(ci): use untagged image name for build provenance attestation

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -29,10 +29,11 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      id-token: write       # AWS OIDC + cosign keyless + provenance
+      id-token: write       # cosign keyless + provenance attestation
       attestations: write   # actions/attest-build-provenance
       packages: write       # ghcr.io push
     strategy:
+      fail-fast: false      # one component's failure must not cancel the others
       matrix:
         component: [backend, frontend, agent]
     steps:
@@ -54,8 +55,11 @@ jobs:
         id: refs
         run: |
           TAG="${{ needs.release-please.outputs.tag_name }}"
-          GHCR_IMAGE="ghcr.io/kube-rca/${{ matrix.component }}:${TAG}"
-          echo "ghcr_image=${GHCR_IMAGE}" >> "$GITHUB_OUTPUT"
+          GHCR_REPO="ghcr.io/kube-rca/${{ matrix.component }}"
+          {
+            echo "ghcr_repo=${GHCR_REPO}"
+            echo "ghcr_image=${GHCR_REPO}:${TAG}"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Build and push
         id: build
@@ -88,7 +92,7 @@ jobs:
       - name: Attest build provenance
         uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2.4.0
         with:
-          subject-name: ${{ steps.refs.outputs.ghcr_image }}
+          subject-name: ${{ steps.refs.outputs.ghcr_repo }}
           subject-digest: ${{ steps.build.outputs.digest }}
           push-to-registry: true
 


### PR DESCRIPTION
## Problem

1.4.1 릴리즈에서 `publish-images`가 frontend의 **Attest build provenance** 단계에서 실패하고, matrix fail-fast로 backend/agent가 취소되어 1.4.1 이미지가 정상 publish되지 못했습니다.

\`\`\`
Error: Invalid image name: ghcr.io/kube-rca/frontend:1.4.1
\`\`\`

`actions/attest-build-provenance`는 `push-to-registry: true`일 때 `subject-name`에 **태그 없는** 이미지 경로를 요구합니다. 이 경로는 release 때만 실행돼 GHCR 전환(#120) PR CI에서는 노출되지 않은 잠복 버그였습니다.

## Fix
- attest `subject-name` -> 태그 없는 repo (`steps.refs.outputs.ghcr_repo` = `ghcr.io/kube-rca/<comp>`)
- `strategy.fail-fast: false` 추가 (한 컴포넌트 실패가 나머지를 취소하지 않도록)
- id-token 권한 주석에서 더 이상 쓰지 않는 'AWS OIDC' 문구 제거

## Validation
- release-please.yaml valid YAML
- 실제 검증은 다음 릴리즈(1.4.2)의 publish-images에서 (release 전용 경로)