### PR TITLE
fix(docker): apk upgrade in frontend image to clear libxml2 CVE

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -18,6 +18,11 @@ RUN npm run build
 # Production stage
 FROM nginx:alpine@sha256:8b1e78743a03dbb2c95171cc58639fef29abc8816598e27fb910ed2e621e589a
 
+# Patch OS packages whose Alpine fix lands before the nginx base image is
+# rebuilt (e.g. libxml2 CVE-2026-6732, fixed in 2.13.9-r1). Keeps the release
+# Trivy gate green without waiting on an upstream nginx rebuild.
+RUN apk upgrade --no-cache
+
 # Copy built files from builder stage
 COPY --from=builder /app/dist /usr/share/nginx/html
 


### PR DESCRIPTION
1.4.3에서 backend(Go 1.26.4)·agent(libcap2)는 Trivy 통과했으나, frontend는 `libxml2 2.13.9-r0`(CVE-2026-6732, fixed in r1)로 잔존 실패. 최신 nginx:alpine digest가 아직 r1 미반영이라, nginx 스테이지에 `apk upgrade --no-cache`를 추가해 빌드 시 OS 패키지를 패치합니다. base 리빌드 주기에 의존하지 않고 Trivy 게이트를 녹색으로 유지.