### PR TITLE
fix(ci): create chart bump PRs instead of pushing main

### DIFF
--- a/.github/workflows/ci-agent.yaml
+++ b/.github/workflows/ci-agent.yaml
@@ -69,10 +69,13 @@ jobs:
     if: github.ref_name == 'main' && github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     permissions:
-      contents: write   # commit helm-values bump back to main
-      packages: write   # push image to GHCR
+      contents: write        # push the chart-bump branch (never main directly)
+      packages: write        # push image to GHCR
+      pull-requests: write   # open/update the chart-bump PR
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0   # full history so the bump branch can merge origin/main
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.12"
@@ -103,24 +106,67 @@ jobs:
             agent/
           docker push \
             "ghcr.io/kube-rca/agent:${{ steps.tag.outputs.image_tag }}"
+      - name: Prepare chart-bump branch
+        run: |
+          set -euo pipefail
+          BRANCH="ci/bump-agent-image"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          # actions/checkout narrows remote.origin.fetch to the triggering ref,
+          # so fetch main (and the bump branch, when it exists) with explicit
+          # refspecs to guarantee the remote-tracking refs are present.
+          git fetch origin "+refs/heads/main:refs/remotes/origin/main"
+
+          # Idempotent branch: reuse the dedicated bump branch if it exists, else
+          # fork it from main. Merge main (never rebase) so the push stays a
+          # fast-forward and needs no --force. `-X theirs` auto-resolves a
+          # concurrently re-touched image-tag line instead of leaving a conflict
+          # that strands the workflow; yq re-sets the tag in the next step.
+          if git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
+            git fetch origin "+refs/heads/$BRANCH:refs/remotes/origin/$BRANCH"
+            git checkout -B "$BRANCH" "origin/$BRANCH"
+            git merge --no-edit -X theirs origin/main
+          else
+            git checkout -B "$BRANCH" origin/main
+          fi
       - name: Update helm values (agent image tag)
         uses: mikefarah/yq@1b9b4ac5187171d2e5e3129be0cfa827c7f9d53d # v4.53.3
         with:
           cmd: yq -i '.agent.image.tag = "${{ steps.tag.outputs.image_tag }}"' charts/kube-rca/kube-rca-values.yaml
-      - name: Commit and push helm values
+      - name: Commit and open or update chart image-bump PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          IMAGE_TAG: ${{ steps.tag.outputs.image_tag }}
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add charts/kube-rca/kube-rca-values.yaml
-          git diff --cached --quiet || git commit -m "chore(charts): bump agent image to ${{ steps.tag.outputs.image_tag }}"
+          set -euo pipefail
+          BRANCH="ci/bump-agent-image"
+          FILE="charts/kube-rca/kube-rca-values.yaml"
+          TITLE="chore(charts): bump agent image to ${IMAGE_TAG}"
 
-          for i in 1 2 3 4 5; do
-            git pull --rebase origin main
-            if git push origin main; then
-              exit 0
-            fi
-            echo "Push failed (attempt $i/5). Retrying in 2s..."
-            sleep 2
-          done
-          echo "Failed to push after 5 attempts."
-          exit 1
+          git add "$FILE"
+          if git diff --cached --quiet; then
+            echo "Chart already at ${IMAGE_TAG}; nothing to commit."
+          else
+            git commit -m "$TITLE"
+          fi
+
+          # Fast-forward push only (no --force); safe because this branch is
+          # written exclusively by CI.
+          git push origin "$BRANCH"
+
+          if [ "$(git rev-list --count "origin/main..$BRANCH")" -eq 0 ]; then
+            echo "Branch has no changes relative to main; skipping PR."
+            exit 0
+          fi
+
+          if [ "$(gh pr list --head "$BRANCH" --base main --state open --json number --jq 'length')" -gt 0 ]; then
+            echo "Open PR already tracks $BRANCH; the push updated it."
+          else
+            gh pr create \
+              --base main \
+              --head "$BRANCH" \
+              --title "$TITLE" \
+              --body "Automated chart image-tag bump from CI (workflow: ${GITHUB_WORKFLOW}, commit: ${GITHUB_SHA}). Sets .agent.image.tag to ${IMAGE_TAG} in ${FILE}."
+          fi

--- a/.github/workflows/ci-backend.yaml
+++ b/.github/workflows/ci-backend.yaml
@@ -99,10 +99,13 @@ jobs:
     if: github.ref_name == 'main' && github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     permissions:
-      contents: write   # commit helm-values bump back to main
-      packages: write   # push image to GHCR
+      contents: write        # push the chart-bump branch (never main directly)
+      packages: write        # push image to GHCR
+      pull-requests: write   # open/update the chart-bump PR
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0   # full history so the bump branch can merge origin/main
       - name: Log in to GHCR
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
@@ -119,24 +122,67 @@ jobs:
             backend/
           docker push \
             "ghcr.io/kube-rca/backend:${{ steps.tag.outputs.image_tag }}"
+      - name: Prepare chart-bump branch
+        run: |
+          set -euo pipefail
+          BRANCH="ci/bump-backend-image"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          # actions/checkout narrows remote.origin.fetch to the triggering ref,
+          # so fetch main (and the bump branch, when it exists) with explicit
+          # refspecs to guarantee the remote-tracking refs are present.
+          git fetch origin "+refs/heads/main:refs/remotes/origin/main"
+
+          # Idempotent branch: reuse the dedicated bump branch if it exists, else
+          # fork it from main. Merge main (never rebase) so the push stays a
+          # fast-forward and needs no --force. `-X theirs` auto-resolves a
+          # concurrently re-touched image-tag line instead of leaving a conflict
+          # that strands the workflow; yq re-sets the tag in the next step.
+          if git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
+            git fetch origin "+refs/heads/$BRANCH:refs/remotes/origin/$BRANCH"
+            git checkout -B "$BRANCH" "origin/$BRANCH"
+            git merge --no-edit -X theirs origin/main
+          else
+            git checkout -B "$BRANCH" origin/main
+          fi
       - name: Update helm values (backend image tag)
         uses: mikefarah/yq@1b9b4ac5187171d2e5e3129be0cfa827c7f9d53d # v4.53.3
         with:
           cmd: yq -i '.backend.image.tag = "${{ steps.tag.outputs.image_tag }}"' charts/kube-rca/kube-rca-values.yaml
-      - name: Commit and push helm values
+      - name: Commit and open or update chart image-bump PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          IMAGE_TAG: ${{ steps.tag.outputs.image_tag }}
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add charts/kube-rca/kube-rca-values.yaml
-          git diff --cached --quiet || git commit -m "chore(charts): bump backend image to ${{ steps.tag.outputs.image_tag }}"
+          set -euo pipefail
+          BRANCH="ci/bump-backend-image"
+          FILE="charts/kube-rca/kube-rca-values.yaml"
+          TITLE="chore(charts): bump backend image to ${IMAGE_TAG}"
 
-          for i in 1 2 3 4 5; do
-            git pull --rebase origin main
-            if git push origin main; then
-              exit 0
-            fi
-            echo "Push failed (attempt $i/5). Retrying in 2s..."
-            sleep 2
-          done
-          echo "Failed to push after 5 attempts."
-          exit 1
+          git add "$FILE"
+          if git diff --cached --quiet; then
+            echo "Chart already at ${IMAGE_TAG}; nothing to commit."
+          else
+            git commit -m "$TITLE"
+          fi
+
+          # Fast-forward push only (no --force); safe because this branch is
+          # written exclusively by CI.
+          git push origin "$BRANCH"
+
+          if [ "$(git rev-list --count "origin/main..$BRANCH")" -eq 0 ]; then
+            echo "Branch has no changes relative to main; skipping PR."
+            exit 0
+          fi
+
+          if [ "$(gh pr list --head "$BRANCH" --base main --state open --json number --jq 'length')" -gt 0 ]; then
+            echo "Open PR already tracks $BRANCH; the push updated it."
+          else
+            gh pr create \
+              --base main \
+              --head "$BRANCH" \
+              --title "$TITLE" \
+              --body "Automated chart image-tag bump from CI (workflow: ${GITHUB_WORKFLOW}, commit: ${GITHUB_SHA}). Sets .backend.image.tag to ${IMAGE_TAG} in ${FILE}."
+          fi

--- a/.github/workflows/ci-frontend.yaml
+++ b/.github/workflows/ci-frontend.yaml
@@ -57,10 +57,13 @@ jobs:
     if: github.ref_name == 'main' && github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     permissions:
-      contents: write   # commit helm-values bump back to main
-      packages: write   # push image to GHCR
+      contents: write        # push the chart-bump branch (never main directly)
+      packages: write        # push image to GHCR
+      pull-requests: write   # open/update the chart-bump PR
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0   # full history so the bump branch can merge origin/main
       - name: Log in to GHCR
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
@@ -77,24 +80,67 @@ jobs:
             frontend/
           docker push \
             "ghcr.io/kube-rca/frontend:${{ steps.tag.outputs.image_tag }}"
+      - name: Prepare chart-bump branch
+        run: |
+          set -euo pipefail
+          BRANCH="ci/bump-frontend-image"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          # actions/checkout narrows remote.origin.fetch to the triggering ref,
+          # so fetch main (and the bump branch, when it exists) with explicit
+          # refspecs to guarantee the remote-tracking refs are present.
+          git fetch origin "+refs/heads/main:refs/remotes/origin/main"
+
+          # Idempotent branch: reuse the dedicated bump branch if it exists, else
+          # fork it from main. Merge main (never rebase) so the push stays a
+          # fast-forward and needs no --force. `-X theirs` auto-resolves a
+          # concurrently re-touched image-tag line instead of leaving a conflict
+          # that strands the workflow; yq re-sets the tag in the next step.
+          if git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
+            git fetch origin "+refs/heads/$BRANCH:refs/remotes/origin/$BRANCH"
+            git checkout -B "$BRANCH" "origin/$BRANCH"
+            git merge --no-edit -X theirs origin/main
+          else
+            git checkout -B "$BRANCH" origin/main
+          fi
       - name: Update helm values (frontend image tag)
         uses: mikefarah/yq@1b9b4ac5187171d2e5e3129be0cfa827c7f9d53d # v4.53.3
         with:
           cmd: yq -i '.frontend.image.tag = "${{ steps.tag.outputs.image_tag }}"' charts/kube-rca/kube-rca-values.yaml
-      - name: Commit and push helm values
+      - name: Commit and open or update chart image-bump PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          IMAGE_TAG: ${{ steps.tag.outputs.image_tag }}
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add charts/kube-rca/kube-rca-values.yaml
-          git diff --cached --quiet || git commit -m "chore(charts): bump frontend image to ${{ steps.tag.outputs.image_tag }}"
+          set -euo pipefail
+          BRANCH="ci/bump-frontend-image"
+          FILE="charts/kube-rca/kube-rca-values.yaml"
+          TITLE="chore(charts): bump frontend image to ${IMAGE_TAG}"
 
-          for i in 1 2 3 4 5; do
-            git pull --rebase origin main
-            if git push origin main; then
-              exit 0
-            fi
-            echo "Push failed (attempt $i/5). Retrying in 2s..."
-            sleep 2
-          done
-          echo "Failed to push after 5 attempts."
-          exit 1
+          git add "$FILE"
+          if git diff --cached --quiet; then
+            echo "Chart already at ${IMAGE_TAG}; nothing to commit."
+          else
+            git commit -m "$TITLE"
+          fi
+
+          # Fast-forward push only (no --force); safe because this branch is
+          # written exclusively by CI.
+          git push origin "$BRANCH"
+
+          if [ "$(git rev-list --count "origin/main..$BRANCH")" -eq 0 ]; then
+            echo "Branch has no changes relative to main; skipping PR."
+            exit 0
+          fi
+
+          if [ "$(gh pr list --head "$BRANCH" --base main --state open --json number --jq 'length')" -gt 0 ]; then
+            echo "Open PR already tracks $BRANCH; the push updated it."
+          else
+            gh pr create \
+              --base main \
+              --head "$BRANCH" \
+              --title "$TITLE" \
+              --body "Automated chart image-tag bump from CI (workflow: ${GITHUB_WORKFLOW}, commit: ${GITHUB_SHA}). Sets .frontend.image.tag to ${IMAGE_TAG} in ${FILE}."
+          fi


### PR DESCRIPTION
## Summary
- Replace CI direct pushes to `main` with component-specific chart image-bump branches and PRs.
- Preserve GHCR image publishing while making chart tag changes reviewable under the new `main` ruleset.
- Use SHA-pinned yq, explicit fetch refspecs, and non-force branch updates.

## Recovery context
- PR #131 merged successfully, but its main CI image build failed only when the old workflow attempted to push Helm values directly to protected `main`.
- The backend image build and GHCR push succeeded; this PR prevents the same failure for backend, agent, and frontend workflows.

## Validation
- `actionlint` passed for all three workflow files.
- `yq -e '.'` parsed all three workflow files.
- `git diff --check` passed.
- `gitleaks detect --no-git` passed on the workflow diff.

## Follow-up
- After this PR merges, create/recover the missing backend chart image-tag bump as a normal reviewed PR.
