### PR TITLE
chore(charts): recover backend image bump

### DIFF
--- a/charts/kube-rca/kube-rca-values.yaml
+++ b/charts/kube-rca/kube-rca-values.yaml
@@ -1,7 +1,7 @@
 backend:
   image:
     repository: ghcr.io/kube-rca/backend
-    tag: backend-7afbfaf
+    tag: backend-b0f154d
   auth:
     secret:
       existingSecret: kube-rca-auth


### PR DESCRIPTION
## Summary
- Recover the backend chart image tag that CI could not commit directly after PR #131.
- Point the chart override to the already-built GHCR image `ghcr.io/kube-rca/backend:backend-b0f154d`.

## Evidence
- The image build and GHCR push for PR #131 completed successfully.
- The subsequent chart commit failed only because the previous CI workflow pushed directly to protected `main`.
- PR #142 changes that workflow to open chart-bump PRs instead.

## Validation
- `helm dependency build charts/kube-rca`
- `helm lint charts/kube-rca -f charts/kube-rca/kube-rca-values.yaml`
- `helm template kube-rca charts/kube-rca -f charts/kube-rca/kube-rca-values.yaml`
- Rendered output contains `ghcr.io/kube-rca/backend:backend-b0f154d`.
- `gitleaks detect --no-git` passed on the diff.
